### PR TITLE
Feat: Song Queue

### DIFF
--- a/flo/AlbumView.swift
+++ b/flo/AlbumView.swift
@@ -279,41 +279,41 @@ struct AlbumView: View {
 struct AlbumViewPreview_Previews: PreviewProvider {
   static var songs: [Song] = [
     Song(
-      id: "0", title: "Song 1", albumId: "", artist: "", trackNumber: 1, discNumber: 0, bitRate: 0,
+        id: "0", title: "Song 1", albumId: "", albumName: "Album", artist: "", trackNumber: 1, discNumber: 0, bitRate: 0,
       sampleRate: 44100,
       suffix: "mp4a", duration: 200, mediaFileId: "0"),
     Song(
-      id: "1", title: "Song 2", albumId: "", artist: "Artist Name", trackNumber: 2, discNumber: 0,
+      id: "1", title: "Song 2", albumId: "", albumName: "Album", artist: "Artist Name", trackNumber: 2, discNumber: 0,
       bitRate: 0,
       sampleRate: 44100,
       suffix: "mp4a", duration: 200, mediaFileId: "1"),
     Song(
-      id: "2", title: "Song 3", albumId: "", artist: "Artist Name", trackNumber: 3, discNumber: 0,
+      id: "2", title: "Song 3", albumId: "", albumName: "Album", artist: "Artist Name", trackNumber: 3, discNumber: 0,
       bitRate: 0,
       sampleRate: 44100,
       suffix: "mp4a", duration: 200, mediaFileId: "2"),
     Song(
-      id: "3", title: "Song 4", albumId: "", artist: "Artist Name", trackNumber: 4, discNumber: 0,
+      id: "3", title: "Song 4", albumId: "", albumName: "Album", artist: "Artist Name", trackNumber: 4, discNumber: 0,
       bitRate: 0,
       sampleRate: 44100,
       suffix: "mp4a", duration: 200, mediaFileId: "3"),
     Song(
-      id: "4", title: "Song 6", albumId: "", artist: "Artist Name", trackNumber: 5, discNumber: 0,
+      id: "4", title: "Song 6", albumId: "", albumName: "Album", artist: "Artist Name", trackNumber: 5, discNumber: 0,
       bitRate: 0,
       sampleRate: 44100,
       suffix: "mp4a", duration: 200, mediaFileId: "4"),
     Song(
-      id: "5", title: "Song 6", albumId: "", artist: "Artist Name", trackNumber: 6, discNumber: 0,
+      id: "5", title: "Song 6", albumId: "", albumName: "Album", artist: "Artist Name", trackNumber: 6, discNumber: 0,
       bitRate: 0,
       sampleRate: 44100,
       suffix: "mp4a", duration: 200, mediaFileId: "5"),
     Song(
-      id: "6", title: "Song 7", albumId: "", artist: "Artist Name", trackNumber: 7, discNumber: 0,
+      id: "6", title: "Song 7", albumId: "", albumName: "Album", artist: "Artist Name", trackNumber: 7, discNumber: 0,
       bitRate: 0,
       sampleRate: 44100,
       suffix: "mp4a", duration: 200, mediaFileId: "6"),
     Song(
-      id: "7", title: "Song 8", albumId: "", artist: "Artist Name", trackNumber: 8, discNumber: 0,
+      id: "7", title: "Song 8", albumId: "", albumName: "Album", artist: "Artist Name", trackNumber: 8, discNumber: 0,
       bitRate: 0,
       sampleRate: 44100,
       suffix: "mp4a", duration: 200, mediaFileId: "7"),

--- a/flo/FloatingPlayerView.swift
+++ b/flo/FloatingPlayerView.swift
@@ -42,11 +42,11 @@ struct FloatingPlayerView: View {
         }
 
         VStack(alignment: .leading) {
-          Text(viewModel.nowPlaying.songName ?? "")
+            Text(viewModel.nowPlaying.title)
             .foregroundColor(.white)
             .customFont(.headline)
             .lineLimit(1)
-          Text(viewModel.nowPlaying.artistName ?? "")
+          Text(viewModel.nowPlaying.artist)
             .foregroundColor(.white)
             .customFont(.subheadline)
             .lineLimit(1)

--- a/flo/FloooViewModel.swift
+++ b/flo/FloooViewModel.swift
@@ -122,21 +122,21 @@ class FloooViewModel: ObservableObject {
     }
   }
 
-  func saveListeningHistory(nowPlayingData: QueueEntity) {
+  func saveListeningHistory(nowPlayingData: Song) {
     FloooService.shared.saveListeningHistory(payload: nowPlayingData)
   }
 
-  func setNowPlayingToScrobbleServer(nowPlaying: QueueEntity) {
+  func setNowPlayingToScrobbleServer(nowPlaying: Song) {
     processScrobble(submission: false, nowPlaying: nowPlaying)
   }
 
-  func scrobble(submission: Bool, nowPlaying: QueueEntity) {
+  func scrobble(submission: Bool, nowPlaying: Song) {
     FloooService.shared.saveListeningHistory(payload: nowPlaying)
     processScrobble(submission: submission, nowPlaying: nowPlaying)
   }
 
-  private func processScrobble(submission: Bool, nowPlaying: QueueEntity) {
-    guard let songId = nowPlaying.id else { return }
+  private func processScrobble(submission: Bool, nowPlaying: Song) {
+    let songId = nowPlaying.id
 
     if isScrobbleAccountStatusChecked {
       let shouldSubmit = isListenBrainzLinked || isLastFmLinked

--- a/flo/Navigation/LibraryView.swift
+++ b/flo/Navigation/LibraryView.swift
@@ -171,7 +171,7 @@ struct LibraryView: View {
 struct LibraryView_Previews: PreviewProvider {
   static private var songs: [Song] = [
     Song(
-      id: "0", title: "Song name", albumId: "", artist: "", trackNumber: 1, discNumber: 0,
+      id: "0", title: "Song name", albumId: "", albumName: "Album", artist: "", trackNumber: 1, discNumber: 0,
       bitRate: 0,
       sampleRate: 44100,
       suffix: "m4a", duration: 100, mediaFileId: "0")

--- a/flo/PlayerView.swift
+++ b/flo/PlayerView.swift
@@ -49,7 +49,7 @@ struct PlayerView: View {
               if viewModel.queue.isEmpty {
                 Text("").customFont(.subheadline)
               } else {
-                Text("From \(viewModel.nowPlaying.albumName ?? "")").customFont(.subheadline)
+                  Text("From \(viewModel.nowPlaying.album)").customFont(.subheadline)
               }
 
               Spacer()
@@ -94,9 +94,9 @@ struct PlayerView: View {
 
           ScrollView {
             VStack(alignment: .leading) {
-              ForEach(viewModel.queue.indices, id: \.self) { idx in
+                ForEach(Array(viewModel.queue.enumerated()), id: \.element) { idx, song in
                 if viewModel.activeQueueIdx < idx {
-                  Text(viewModel.queue[idx].songName ?? "")
+                    Text(song.title)
                     .customFont(.body)
                     .fontWeight(.medium)
                     .padding(.bottom, 20)
@@ -158,14 +158,14 @@ struct PlayerView: View {
           Spacer()
 
           VStack(alignment: .center, spacing: 10) {
-            Text(viewModel.nowPlaying.songName ?? "")
+              Text(viewModel.nowPlaying.title)
               .foregroundColor(.white)
               .customFont(.title1)
               .fontWeight(.bold)
               .multilineTextAlignment(.center)
               .lineLimit(3)
 
-            Text(viewModel.nowPlaying.artistName ?? "")
+            Text(viewModel.nowPlaying.artist)
               .foregroundColor(.white.opacity(0.8))
               .customFont(.title3)
               .multilineTextAlignment(.center)
@@ -218,7 +218,7 @@ struct PlayerView: View {
 
               Text(
                 viewModel.isPlayFromSource
-                  ? "\(viewModel.nowPlaying.suffix ?? "")   \(viewModel.nowPlaying.bitRate.description)"
+                ? "\(viewModel.nowPlaying.suffix)   \(viewModel.nowPlaying.bitRate.description)"
                   : "\(TranscodingSettings.targetFormat)   \(UserDefaultsManager.maxBitRate)"
               )
               .foregroundColor(.white)

--- a/flo/PlaylistDetailView.swift
+++ b/flo/PlaylistDetailView.swift
@@ -112,7 +112,7 @@ struct PlaylistDetailView: View {
           .listRowSeparator(.hidden)
           .contentShape(Rectangle())
           .onTapGesture {
-            playerViewModel.playBySong(
+            playerViewModel.playItemFromIdx(
               idx: idx, item: viewModel.playlist, isFromLocal: false)
           }
           .contextMenu {

--- a/flo/Resources/Localizable.xcstrings
+++ b/flo/Resources/Localizable.xcstrings
@@ -875,6 +875,12 @@
         }
       }
     },
+    "Play Last" : {
+
+    },
+    "Play Next" : {
+
+    },
     "Player color" : {
       "localizations" : {
         "en" : {

--- a/flo/Shared/Models/Song.swift
+++ b/flo/Shared/Models/Song.swift
@@ -12,6 +12,7 @@ struct Song: Codable, Identifiable, Hashable {
   let title: String
   let artist: String
   let albumId: String
+  let album: String
   let trackNumber: Int
   let discNumber: Int
   let bitRate: Int
@@ -27,6 +28,7 @@ struct Song: Codable, Identifiable, Hashable {
     case title
     case artist
     case albumId
+    case album
     case trackNumber
     case discNumber
     case bitRate
@@ -43,6 +45,7 @@ struct Song: Codable, Identifiable, Hashable {
     self.title = try container.decode(String.self, forKey: .title)
     self.artist = try container.decode(String.self, forKey: .artist)
     self.albumId = try container.decode(String.self, forKey: .albumId)
+    self.album = try container.decode(String.self, forKey: .album)
     self.trackNumber = try container.decode(Int.self, forKey: .trackNumber)
     self.discNumber = try container.decode(Int.self, forKey: .discNumber)
     self.bitRate = try container.decode(Int.self, forKey: .bitRate)
@@ -53,7 +56,7 @@ struct Song: Codable, Identifiable, Hashable {
   }
 
   init(
-    id: String, title: String, albumId: String, artist: String, trackNumber: Int, discNumber: Int,
+    id: String, title: String, albumId: String, albumName: String, artist: String, trackNumber: Int, discNumber: Int,
     bitRate: Int,
     sampleRate: Int,
     suffix: String, duration: Double, mediaFileId: String
@@ -62,6 +65,7 @@ struct Song: Codable, Identifiable, Hashable {
     self.title = title
     self.artist = artist
     self.albumId = albumId
+    self.album = albumName
     self.trackNumber = Int(trackNumber)
     self.discNumber = Int(discNumber)
     self.bitRate = Int(bitRate)
@@ -76,6 +80,7 @@ struct Song: Codable, Identifiable, Hashable {
     self.title = song.title ?? "N/A"
     self.artist = song.artistName ?? "N/A"
     self.albumId = song.albumId ?? ""
+    self.album = song.album ?? ""
     self.trackNumber = Int(song.trackNumber)
     self.discNumber = Int(song.discNumber)
     self.bitRate = Int(song.bitRate)

--- a/flo/Shared/Services/FloooService.swift
+++ b/flo/Shared/Services/FloooService.swift
@@ -15,14 +15,13 @@ class FloooService {
     return await CoreDataManager.shared.getRecordsByEntityBatched(entity: HistoryEntity.self)
   }
 
-  func saveListeningHistory(payload: QueueEntity) {
+  func saveListeningHistory(payload: Song) {
     let currentSession = HistoryEntity(context: CoreDataManager.shared.viewContext)
 
     currentSession.albumId = payload.albumId
-    currentSession.artistName = payload.artistName
-    currentSession.trackName = payload.songName
-    currentSession.albumName = payload.albumName
-    currentSession.artistName = payload.artistName
+    currentSession.artistName = payload.artist
+    currentSession.trackName = payload.title
+    currentSession.albumName = payload.album
     currentSession.timestamp = Date()
 
     CoreDataManager.shared.saveRecord()

--- a/flo/Shared/Services/PlaybackService.swift
+++ b/flo/Shared/Services/PlaybackService.swift
@@ -14,6 +14,15 @@ class PlaybackService {
   func getQueue() -> [QueueEntity] {
     return CoreDataManager.shared.getRecordsByEntity(entity: QueueEntity.self)
   }
+    
+  func getQueueAsSongs() -> [Song] {
+      let queue = self.getQueue()
+      var songs = queue.map {
+          return Song(id: $0.id ?? "", title: $0.songName ?? "", albumId: $0.albumId ?? "", albumName: $0.albumName ?? "", artist: $0.artistName ?? "", trackNumber: 0, discNumber: 0, bitRate: Int($0.bitRate), sampleRate: Int($0.sampleRate), suffix: $0.suffix ?? "", duration: $0.duration, mediaFileId: $0.id ?? "")
+      }
+      return songs
+      
+  }
 
   func clearQueue() {
     CoreDataManager.shared.deleteRecords(entity: QueueEntity.self)
@@ -28,7 +37,47 @@ class PlaybackService {
     return head + tail
   }
 
-  func addToQueue<T: Playable>(item: T, isFromLocal: Bool = false) -> [QueueEntity] {
+//    func addToQueueNext(song: Song, curIdx: Int, isFromLocal: Bool = false) -> [QueueEntity] {
+//      var curQueue = getQueue()
+//      let queue = QueueEntity(context: CoreDataManager.shared.viewContext)
+//
+//      queue.id = song.mediaFileId == "" ? song.id : song.mediaFileId
+//      queue.albumId = song.albumId
+//      queue.albumName = song.album
+//      queue.artistName = song.artist
+//      queue.bitRate = Int16(song.bitRate)
+//      queue.sampleRate = Int32(song.sampleRate)
+//      queue.songName = song.title
+//      queue.suffix = song.suffix
+//      queue.isFromLocal = isFromLocal
+//      queue.duration = song.duration
+//      
+//      curQueue.insert(queue, at: curIdx + 1)
+//      
+//      self.clearQueue()
+//      
+//      for citem in curQueue {
+//          let newCItem = QueueEntity(context: CoreDataManager.shared.viewContext)
+//          
+//          newCItem.id = citem.id
+//          newCItem.albumId = citem.albumId
+//          newCItem.artistName = citem.artistName
+//          newCItem.bitRate = citem.bitRate
+//          newCItem.sampleRate = citem.sampleRate
+//          newCItem.songName = citem.songName
+//          newCItem.suffix = citem.suffix
+//          newCItem.isFromLocal = citem.isFromLocal
+//          newCItem.duration = citem.duration
+//          
+//          CoreDataManager.shared.saveRecord()
+//          
+//      }
+//      
+//      return self.getQueue()
+//        
+//    }
+    
+  func setQueue<T: Playable>(item: T, isFromLocal: Bool = false) -> [QueueEntity] {
     self.clearQueue()
 
     for song in item.songs {
@@ -36,7 +85,7 @@ class PlaybackService {
 
       queue.id = song.mediaFileId == "" ? song.id : song.mediaFileId
       queue.albumId = song.albumId
-      queue.albumName = item.name
+        queue.albumName = song.album
       queue.artistName = song.artist
       queue.bitRate = Int16(song.bitRate)
       queue.sampleRate = Int32(song.sampleRate)
@@ -50,4 +99,26 @@ class PlaybackService {
 
     return self.getQueue()
   }
+    
+    func setQueueSongs(songs: [Song], isFromLocal: Bool = false) {
+      self.clearQueue()
+
+      for song in songs {
+        let queue = QueueEntity(context: CoreDataManager.shared.viewContext)
+
+        queue.id = song.mediaFileId == "" ? song.id : song.mediaFileId
+        queue.albumId = song.albumId
+        queue.albumName = song.album
+        queue.artistName = song.artist
+        queue.bitRate = Int16(song.bitRate)
+        queue.sampleRate = Int32(song.sampleRate)
+        queue.songName = song.title
+        queue.suffix = song.suffix
+        queue.isFromLocal = isFromLocal
+        queue.duration = song.duration
+
+        CoreDataManager.shared.saveRecord()
+      }
+    }
+
 }

--- a/flo/Shared/Services/PlaybackService.swift
+++ b/flo/Shared/Services/PlaybackService.swift
@@ -17,11 +17,9 @@ class PlaybackService {
     
   func getQueueAsSongs() -> [Song] {
       let queue = self.getQueue()
-      var songs = queue.map {
+      return queue.map {
           return Song(id: $0.id ?? "", title: $0.songName ?? "", albumId: $0.albumId ?? "", albumName: $0.albumName ?? "", artist: $0.artistName ?? "", trackNumber: 0, discNumber: 0, bitRate: Int($0.bitRate), sampleRate: Int($0.sampleRate), suffix: $0.suffix ?? "", duration: $0.duration, mediaFileId: $0.id ?? "")
-      }
-      return songs
-      
+      }      
   }
 
   func clearQueue() {
@@ -37,45 +35,6 @@ class PlaybackService {
     return head + tail
   }
 
-//    func addToQueueNext(song: Song, curIdx: Int, isFromLocal: Bool = false) -> [QueueEntity] {
-//      var curQueue = getQueue()
-//      let queue = QueueEntity(context: CoreDataManager.shared.viewContext)
-//
-//      queue.id = song.mediaFileId == "" ? song.id : song.mediaFileId
-//      queue.albumId = song.albumId
-//      queue.albumName = song.album
-//      queue.artistName = song.artist
-//      queue.bitRate = Int16(song.bitRate)
-//      queue.sampleRate = Int32(song.sampleRate)
-//      queue.songName = song.title
-//      queue.suffix = song.suffix
-//      queue.isFromLocal = isFromLocal
-//      queue.duration = song.duration
-//      
-//      curQueue.insert(queue, at: curIdx + 1)
-//      
-//      self.clearQueue()
-//      
-//      for citem in curQueue {
-//          let newCItem = QueueEntity(context: CoreDataManager.shared.viewContext)
-//          
-//          newCItem.id = citem.id
-//          newCItem.albumId = citem.albumId
-//          newCItem.artistName = citem.artistName
-//          newCItem.bitRate = citem.bitRate
-//          newCItem.sampleRate = citem.sampleRate
-//          newCItem.songName = citem.songName
-//          newCItem.suffix = citem.suffix
-//          newCItem.isFromLocal = citem.isFromLocal
-//          newCItem.duration = citem.duration
-//          
-//          CoreDataManager.shared.saveRecord()
-//          
-//      }
-//      
-//      return self.getQueue()
-//        
-//    }
     
   func setQueue<T: Playable>(item: T, isFromLocal: Bool = false) -> [QueueEntity] {
     self.clearQueue()

--- a/flo/SongView.swift
+++ b/flo/SongView.swift
@@ -68,7 +68,7 @@ struct SongView: View {
               } label: {
                   HStack {
                     Text("Play Last")
-                    Image(systemName: "text.line.first.and.arrowtriangle.forward")
+                    Image(systemName: "text.line.last.and.arrowtriangle.forward")
                   }
                 }
             if !song.fileUrl.isEmpty {

--- a/flo/SongView.swift
+++ b/flo/SongView.swift
@@ -50,11 +50,27 @@ struct SongView: View {
         .listRowSeparator(.hidden)
         .contentShape(Rectangle())
         .onTapGesture {
-          playerViewModel.playBySong(
+          playerViewModel.playItemFromIdx(
             idx: idx, item: viewModel.album, isFromLocal: viewModel.isDownloaded)
         }
         .contextMenu {
           VStack {
+              Button {
+                  playerViewModel.queueSongNext(song: song, isFromLocal: viewModel.isDownloaded)
+              } label: {
+                  HStack {
+                    Text("Play Next")
+                    Image(systemName: "text.line.first.and.arrowtriangle.forward")
+                  }
+                }
+              Button {
+                  playerViewModel.queueSongLast(song: song, isFromLocal: viewModel.isDownloaded)
+              } label: {
+                  HStack {
+                    Text("Play Last")
+                    Image(systemName: "text.line.first.and.arrowtriangle.forward")
+                  }
+                }
             if !song.fileUrl.isEmpty {
               Button(role: .destructive) {
                 viewModel.removeDownloadSong(album: viewModel.album, songId: song.id)
@@ -91,42 +107,42 @@ struct SongView: View {
 struct SongView_Previews: PreviewProvider {
   static let songs: [Song] = [
     Song(
-      id: "0", title: "Song 1", albumId: "", artist: "Artist Name", trackNumber: 1, discNumber: 0,
+      id: "0", title: "Song 1", albumId: "", albumName: "Album", artist: "Artist Name", trackNumber: 1, discNumber: 0,
       bitRate: 0,
       sampleRate: 44100,
       suffix: "mp4a", duration: 200, mediaFileId: "0"),
     Song(
-      id: "1", title: "Song 2", albumId: "", artist: "Artist Name", trackNumber: 2, discNumber: 0,
+      id: "1", title: "Song 2", albumId: "", albumName: "Album", artist: "Artist Name", trackNumber: 2, discNumber: 0,
       bitRate: 0,
       sampleRate: 44100,
       suffix: "mp4a", duration: 200, mediaFileId: "1"),
     Song(
-      id: "2", title: "Song 3", albumId: "", artist: "Artist Name", trackNumber: 3, discNumber: 0,
+      id: "2", title: "Song 3", albumId: "", albumName: "Album", artist: "Artist Name", trackNumber: 3, discNumber: 0,
       bitRate: 0,
       sampleRate: 44100,
       suffix: "mp4a", duration: 200, mediaFileId: "2"),
     Song(
-      id: "3", title: "Song 4", albumId: "", artist: "Artist Name", trackNumber: 4, discNumber: 0,
+      id: "3", title: "Song 4", albumId: "", albumName: "Album", artist: "Artist Name", trackNumber: 4, discNumber: 0,
       bitRate: 0,
       sampleRate: 44100,
       suffix: "mp4a", duration: 200, mediaFileId: "3"),
     Song(
-      id: "4", title: "Song 5", albumId: "", artist: "Artist Name", trackNumber: 5, discNumber: 0,
+      id: "4", title: "Song 5", albumId: "", albumName: "Album", artist: "Artist Name", trackNumber: 5, discNumber: 0,
       bitRate: 0,
       sampleRate: 44100,
       suffix: "mp4a", duration: 200, mediaFileId: "4"),
     Song(
-      id: "5", title: "Song 6", albumId: "", artist: "Artist Name", trackNumber: 6, discNumber: 0,
+      id: "5", title: "Song 6", albumId: "", albumName: "Album", artist: "Artist Name", trackNumber: 6, discNumber: 0,
       bitRate: 0,
       sampleRate: 44100,
       suffix: "mp4a", duration: 200, mediaFileId: "5"),
     Song(
-      id: "6", title: "Song 7", albumId: "", artist: "Artist Name", trackNumber: 7, discNumber: 0,
+      id: "6", title: "Song 7", albumId: "", albumName: "Album", artist: "Artist Name", trackNumber: 7, discNumber: 0,
       bitRate: 0,
       sampleRate: 44100,
       suffix: "mp4a", duration: 200, mediaFileId: "6"),
     Song(
-      id: "7", title: "Song 8", albumId: "", artist: "Artist Name", trackNumber: 8, discNumber: 0,
+      id: "7", title: "Song 8", albumId: "", albumName: "Album", artist: "Artist Name", trackNumber: 8, discNumber: 0,
       bitRate: 0,
       sampleRate: 44100,
       suffix: "mp4a", duration: 200, mediaFileId: "7"),

--- a/flo/SongsView.swift
+++ b/flo/SongsView.swift
@@ -27,7 +27,7 @@ struct SongsView: View {
   var body: some View {
     ScrollView {
       LazyVStack {
-        ForEach(Array(filteredSongs.enumerated()), id: \.element) { idx, song in
+          ForEach(Array(filteredSongs.enumerated()), id: \.offset) { idx, song in
           VStack {
             HStack {
               LazyImage(url: URL(string: viewModel.getAlbumCoverArt(id: song.albumId))) { state in
@@ -73,7 +73,7 @@ struct SongsView: View {
 
             playlist.songs = Array(songs)
 
-            playerViewModel.playBySong(
+            playerViewModel.playItemFromIdx(
               idx: 0, item: playlist, isFromLocal: false)
           }
           .frame(maxWidth: .infinity, alignment: .leading)

--- a/flo/flo.xcdatamodeld/flo.xcdatamodel/contents
+++ b/flo/flo.xcdatamodeld/flo.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24C101" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23211.1" systemVersion="24C101" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
     <entity name="HistoryEntity" representedClassName="HistoryEntity" syncable="YES" codeGenerationType="class">
         <attribute name="albumId" optional="YES" attributeType="String"/>
         <attribute name="albumName" optional="YES" attributeType="String"/>
@@ -36,6 +36,7 @@
         <attribute name="suffix" optional="YES" attributeType="String"/>
     </entity>
     <entity name="SongEntity" representedClassName="SongEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="album" optional="YES" attributeType="String"/>
         <attribute name="albumId" attributeType="String"/>
         <attribute name="artistName" optional="YES" attributeType="String"/>
         <attribute name="bitRate" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>


### PR DESCRIPTION
Added the ability to add individual songs to the queue (beginning or end).
This involved changing the PlayerViewModel queue to a song array.

Demo:
Long press song.
![IMG_9920](https://github.com/user-attachments/assets/3953ce13-d98b-43c6-94b7-53025882ce40)

Added next in the queue.
![IMG_9921](https://github.com/user-attachments/assets/4ed50216-0d19-44c0-8802-5f5e287dd035)
