### PR TITLE
Don't sort by track number when viewing a playlist.

### DIFF
--- a/flo/AlbumViewModel.swift
+++ b/flo/AlbumViewModel.swift
@@ -306,7 +306,6 @@ class AlbumViewModel: ObservableObject {
           }
 
           self.playlist.songs.append(contentsOf: remoteSongs)
-          self.playlist.songs.sort { $0.trackNumber < $1.trackNumber }
 
         case .failure(let error):
           self.error = error


### PR DESCRIPTION
When loading a playlist, use the track order from the playlist and not the individual tracks. Resolves https://github.com/kepelet/flo/issues/77