### PR TITLE
Sort album tracks by disc number and track number

### DIFF
--- a/flo/AlbumViewModel.swift
+++ b/flo/AlbumViewModel.swift
@@ -83,7 +83,12 @@ class AlbumViewModel: ObservableObject {
             self.album.songs.append(contentsOf: remoteSongs)
           }
 
-          self.album.songs.sort { $0.trackNumber < $1.trackNumber }
+          self.album.songs.sort { (lhs, rhs) in
+            if lhs.discNumber == rhs.discNumber {
+              return lhs.trackNumber < lhs.trackNumber
+            }
+            return lhs.discNumber < rhs.discNumber
+          }
 
         case .failure(let error):
           self.error = error


### PR DESCRIPTION
When an album has multiple discs, Flo is currently sorting tracks by track number only, folding each disc into the order (so, 1-01, 2-01, 3-01, 1-02, 2-02, 3-02 etc).

Change sorting so that disc numbers are sorted before track numbers.