### PR TITLE
Performance improvements for large queues

### DIFF
--- a/flo/PlayerView.swift
+++ b/flo/PlayerView.swift
@@ -97,7 +97,7 @@ struct PlayerView: View {
           .padding(.bottom, 5)
 
           ScrollView {
-            VStack(alignment: .leading) {
+            LazyVStack(alignment: .leading) {
               ForEach(viewModel.queue.indices, id: \.self) { idx in
                 HStack(alignment: .top) {
                   VStack(alignment: .leading) {

--- a/flo/Shared/Services/PlaybackService.swift
+++ b/flo/Shared/Services/PlaybackService.swift
@@ -31,22 +31,23 @@ class PlaybackService {
   func addToQueue<T: Playable>(item: T, isFromLocal: Bool = false) -> [QueueEntity] {
     self.clearQueue()
 
-    for song in item.songs {
-      let queue = QueueEntity(context: CoreDataManager.shared.viewContext)
-
-      queue.id = song.mediaFileId == "" ? song.id : song.mediaFileId
-      queue.albumId = song.albumId
-      queue.albumName = item.name
-      queue.artistName = song.artist
-      queue.bitRate = Int16(song.bitRate)
-      queue.sampleRate = Int32(song.sampleRate)
-      queue.songName = song.title
-      queue.suffix = song.suffix
-      queue.isFromLocal = isFromLocal
-      queue.duration = song.duration
-
-      CoreDataManager.shared.saveRecord()
+    let objects = item.songs.map { song in
+        return [
+            "id": song.mediaFileId == "" ? song.id : song.mediaFileId,
+            "albumId": song.albumId,
+            "albumName": item.name,
+            "artistName": song.artist,
+            "bitRate": song.bitRate,
+            "sampleRate": song.sampleRate,
+            "songName": song.title,
+            "suffix": song.suffix,
+            "isFromLocal": isFromLocal,
+            "duration": song.duration
+        ] as [String : Any]
     }
+
+    let request = NSBatchInsertRequest(entity: QueueEntity.entity(), objects: objects)
+    _ = try? CoreDataManager.shared.viewContext.execute(request)
 
     return self.getQueue()
   }


### PR DESCRIPTION
Playing a song from the song list currently queues the entire library. My library contains ~3.5k tracks which caused me some performance issues. The queuing process caused the app to freeze for several seconds, and afterward, it took roughly 15 seconds to restart while using up to 1.2gb of memory.

I fixed this by using a batch api in `addToQueue` and replacing the playback queue `VStack` with a `LazyVStack`. After optimization, memory usage dropped to ~40mb and launch time decreased to under a second on my iPhone 12 running iOS26.