### PR TITLE
Hotfix: Small Screen Crash

### DIFF
--- a/flo/StatCardView.swift
+++ b/flo/StatCardView.swift
@@ -43,7 +43,6 @@ struct StatCard: View {
           Text(title)
             .foregroundColor(.secondary)
             .customFont(.body)
-            .minimumScaleFactor(0.7)
 
           Spacer()
 
@@ -61,7 +60,6 @@ struct StatCard: View {
             .lineSpacing(2)
             .fontWeight(.bold)
             .lineLimit(2)
-            .minimumScaleFactor(0.7)
 
           if let subtitle = subtitle {
             Text(subtitle)
@@ -69,7 +67,6 @@ struct StatCard: View {
               .customFont(.subheadline)
               .lineSpacing(2)
               .lineLimit(2)
-              .minimumScaleFactor(0.7)
           }
         }
       }
@@ -84,7 +81,6 @@ struct StatCard: View {
           Text(title)
             .foregroundColor(.secondary)
             .customFont(.body)
-            .minimumScaleFactor(0.7)
 
           Spacer()
 
@@ -102,7 +98,6 @@ struct StatCard: View {
             .lineSpacing(2)
             .fontWeight(.bold)
             .lineLimit(2)
-            .minimumScaleFactor(0.7)
 
           if let subtitle = subtitle {
             Text(subtitle)
@@ -110,7 +105,6 @@ struct StatCard: View {
               .customFont(.subheadline)
               .lineSpacing(2)
               .lineLimit(2)
-              .minimumScaleFactor(0.7)
           }
         }
       }


### PR DESCRIPTION
so there's again the bug on the homeview from #101 this time when the stat cards are populated with data and we switch from another tab back to home view.

there's a hanging in calculating the geometry with EqualHeightItem when StatCard have a dynamic scaling so without changing the EqualHeight the next best thing is:

- removed scale factor in stat cards

sorry i didn't catch this before
