### PR TITLE
add support for navidrome artist radio

### DIFF
--- a/flo/ArtistDetailView.swift
+++ b/flo/ArtistDetailView.swift
@@ -9,8 +9,10 @@ import SwiftUI
 
 struct ArtistDetailView: View {
   @EnvironmentObject var viewModel: AlbumViewModel
+  @EnvironmentObject var playerViewModel: PlayerViewModel
 
   @State private var isExpanded = false
+  @State private var isLoadingRadio = false
 
   var artist: Artist
 
@@ -55,6 +57,50 @@ struct ArtistDetailView: View {
       .onAppear {
         viewModel.fetchAlbumsByArtist(id: artist.id)
       }
+
+      Button(action: {
+        isLoadingRadio = true
+        RadioService.shared.getSimilarSongs(id: artist.id) { result in
+          DispatchQueue.main.async {
+            isLoadingRadio = false
+            switch result {
+            case .success(let songs):
+              print("Artist Radio: got \(songs.count) songs")
+              if !songs.isEmpty {
+                let playable = ArtistRadioPlayable(
+                  id: artist.id,
+                  name: "\(artist.name) Radio",
+                  songs: songs,
+                  artist: artist.name
+                )
+                playerViewModel.playItem(item: playable, isFromLocal: false)
+              }
+            case .failure(let error):
+              print("Artist Radio error: \(error)")
+            }
+          }
+        }
+      }) {
+        HStack {
+          if isLoadingRadio {
+            ProgressView()
+              .tint(.white)
+          } else {
+            Image(systemName: "dot.radiowaves.up.forward")
+          }
+          Text("Artist Radio")
+        }
+        .font(.subheadline)
+        .fontWeight(.semibold)
+        .foregroundColor(.white)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(Color.accentColor)
+        .cornerRadius(20)
+      }
+      .disabled(isLoadingRadio)
+      .padding(.horizontal)
+      .padding(.bottom, 8)
 
       LazyVGrid(columns: columns) {
         ForEach(viewModel.artistAlbums) { album in

--- a/flo/Resources/Localizable.xcstrings
+++ b/flo/Resources/Localizable.xcstrings
@@ -253,6 +253,9 @@
         }
       }
     },
+    "Artist Radio" : {
+
+    },
     "Artists" : {
       "localizations" : {
         "en" : {

--- a/flo/Shared/Models/Radio.swift
+++ b/flo/Shared/Models/Radio.swift
@@ -99,3 +99,64 @@ struct RadioEntity: Playable {
   var songs: [Song]
   var artist: String
 }
+
+// MARK: - Artist Radio (getSimilarSongs2)
+
+struct SimilarSongsList: SubsonicResponseData {
+  static var key: String { "similarSongs2" }
+  let song: [Song]
+
+  private enum CodingKeys: String, CodingKey {
+    case song
+  }
+
+  private enum SubsonicSongKeys: String, CodingKey {
+    case id, title, artist, albumId, album, track, discNumber, bitRate, samplingRate, suffix,
+      duration, mediaFileId
+  }
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    var songsContainer = try container.nestedUnkeyedContainer(forKey: .song)
+
+    var songs: [Song] = []
+    while !songsContainer.isAtEnd {
+      let s = try songsContainer.nestedContainer(keyedBy: SubsonicSongKeys.self)
+      songs.append(
+        Song(
+          id: try s.decode(String.self, forKey: .id),
+          title: try s.decode(String.self, forKey: .title),
+          albumId: try s.decodeIfPresent(String.self, forKey: .albumId) ?? "",
+          albumName: try s.decodeIfPresent(String.self, forKey: .album) ?? "",
+          artist: try s.decode(String.self, forKey: .artist),
+          trackNumber: try s.decodeIfPresent(Int.self, forKey: .track) ?? 0,
+          discNumber: try s.decodeIfPresent(Int.self, forKey: .discNumber) ?? 0,
+          bitRate: try s.decodeIfPresent(Int.self, forKey: .bitRate) ?? 0,
+          sampleRate: try s.decodeIfPresent(Int.self, forKey: .samplingRate) ?? 0,
+          suffix: try s.decodeIfPresent(String.self, forKey: .suffix) ?? "",
+          duration: try s.decode(Double.self, forKey: .duration),
+          mediaFileId: try s.decodeIfPresent(String.self, forKey: .mediaFileId) ?? ""
+        ))
+    }
+    self.song = songs
+  }
+}
+
+struct SimilarSongsResponse: Codable {
+  let subsonicResponse: SubsonicResponse<SimilarSongsList>
+
+  private enum CodingKeys: String, CodingKey {
+    case subsonicResponse = "subsonic-response"
+  }
+
+  var songs: [Song] {
+    return subsonicResponse.data?.song ?? []
+  }
+}
+
+struct ArtistRadioPlayable: Playable {
+  var id: String
+  var name: String
+  var songs: [Song]
+  var artist: String
+}

--- a/flo/Shared/Services/RadioService.swift
+++ b/flo/Shared/Services/RadioService.swift
@@ -11,12 +11,26 @@ class RadioService {
   }
 
   func getAllRadios(completion: @escaping (Result<[Radio], Error>) -> Void) {
-    
+
     APIManager.shared.SubsonicEndpointRequest(endpoint: API.SubsonicEndpoint.radios, parameters: nil) {
       (response: DataResponse<RadioListResponse, AFError>) in
       switch response.result {
       case .success(let radios):
         completion(.success(radios.radioStations))
+      case .failure(let error):
+        completion(.failure(error))
+      }
+    }
+  }
+
+  func getSimilarSongs(id: String, count: Int = 50, completion: @escaping (Result<[Song], Error>) -> Void) {
+    let params: [String: Any] = ["id": id, "count": count]
+
+    APIManager.shared.SubsonicEndpointRequest(endpoint: API.SubsonicEndpoint.similarSongs, parameters: params) {
+      (response: DataResponse<SimilarSongsResponse, AFError>) in
+      switch response.result {
+      case .success(let result):
+        completion(.success(result.songs))
       case .failure(let error):
         completion(.failure(error))
       }

--- a/flo/Shared/Utils/Constants.swift
+++ b/flo/Shared/Utils/Constants.swift
@@ -29,6 +29,7 @@ struct API {
     static let download = "/rest/download"
     static let scrobble = "/rest/scrobble"
     static let radios = "/rest/getInternetRadioStations"
+    static let similarSongs = "/rest/getSimilarSongs2"
   }
 }
 


### PR DESCRIPTION
This adds one more radio function to the app. Adds a Artist radio button to each artist view. Uses navidromes subsonic api /getSimilarSongs2 api to pull up to 100 songs into the queue and starts playback