### PR TITLE
Transparent caching with pull-to-refresh

### DIFF
--- a/flo.xcodeproj/project.pbxproj
+++ b/flo.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		C49495852C1C26D4006B4D1E /* ScanStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C49495842C1C26D4006B4D1E /* ScanStatusService.swift */; };
 		C4A4BF312C14433D00363290 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A4BF302C14433D00363290 /* HomeView.swift */; };
 		C4A4BF332C14437700363290 /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A4BF322C14437700363290 /* LibraryView.swift */; };
+		02E566BC379A4C25B4AB907C /* CachedSongsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8455A32A2A31C3AA7C4DC99 /* CachedSongsView.swift */; };
 		C4A4BF372C14442F00363290 /* DownloadsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A4BF362C14442F00363290 /* DownloadsView.swift */; };
 		C4A4BF392C14445000363290 /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A4BF382C14445000363290 /* PreferencesView.swift */; };
 		C4A4BF3D2C1455A100363290 /* FloatingPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A4BF3C2C1455A100363290 /* FloatingPlayerView.swift */; };
@@ -241,6 +242,7 @@
 		C49495842C1C26D4006B4D1E /* ScanStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanStatusService.swift; sourceTree = "<group>"; };
 		C4A4BF302C14433D00363290 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		C4A4BF322C14437700363290 /* LibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryView.swift; sourceTree = "<group>"; };
+		E8455A32A2A31C3AA7C4DC99 /* CachedSongsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedSongsView.swift; sourceTree = "<group>"; };
 		C4A4BF362C14442F00363290 /* DownloadsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsView.swift; sourceTree = "<group>"; };
 		C4A4BF382C14445000363290 /* PreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
 		C4A4BF3C2C1455A100363290 /* FloatingPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPlayerView.swift; sourceTree = "<group>"; };
@@ -450,6 +452,7 @@
 			children = (
 				C4A4BF302C14433D00363290 /* HomeView.swift */,
 				C4A4BF322C14437700363290 /* LibraryView.swift */,
+				E8455A32A2A31C3AA7C4DC99 /* CachedSongsView.swift */,
 				C4A4BF362C14442F00363290 /* DownloadsView.swift */,
 				C4A4BF382C14445000363290 /* PreferencesView.swift */,
 			);
@@ -734,6 +737,7 @@
 				C415F54E2C11908100E3E1D2 /* AuthViewModel.swift in Sources */,
 				C42B25842F44551B00E62008 /* PlaybackCoordinator.swift in Sources */,
 				50C912912F5DD9990087EE61 /* IAPLoginView.swift in Sources */,
+				02E566BC379A4C25B4AB907C /* CachedSongsView.swift in Sources */,
 				C4A4BF372C14442F00363290 /* DownloadsView.swift in Sources */,
 				C4100A692CE78B25001BC9BE /* PlaylistView.swift in Sources */,
 				C440228D2C09BE2E004EE9CD /* PlayerView.swift in Sources */,

--- a/flo.xcodeproj/project.pbxproj
+++ b/flo.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		C4824D232CE8C41F003EAB52 /* Playable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4824D222CE8C41D003EAB52 /* Playable.swift */; };
 		C4824D272CE908DC003EAB52 /* SongsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4824D262CE908DA003EAB52 /* SongsView.swift */; };
 		C4875E002C149D9000D9BAEB /* AlbumService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4875DFF2C149D9000D9BAEB /* AlbumService.swift */; };
+		C4CACHE012D7B0000003B9C4F /* StreamCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4CACHE002D7B0000003B9C4F /* StreamCacheManager.swift */; };
 		C4875E022C149DDD00D9BAEB /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4875E012C149DDD00D9BAEB /* AuthService.swift */; };
 		C4875E042C149F9A00D9BAEB /* APIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4875E032C149F9A00D9BAEB /* APIManager.swift */; };
 		C49134532C15BE0C00CCF2EB /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = C49134522C15BE0C00CCF2EB /* Strings.swift */; };
@@ -231,6 +232,7 @@
 		C4824D222CE8C41D003EAB52 /* Playable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Playable.swift; sourceTree = "<group>"; };
 		C4824D262CE908DA003EAB52 /* SongsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongsView.swift; sourceTree = "<group>"; };
 		C4875DFF2C149D9000D9BAEB /* AlbumService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumService.swift; sourceTree = "<group>"; };
+		C4CACHE002D7B0000003B9C4F /* StreamCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCacheManager.swift; sourceTree = "<group>"; };
 		C4875E012C149DDD00D9BAEB /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		C4875E032C149F9A00D9BAEB /* APIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIManager.swift; sourceTree = "<group>"; };
 		C49134522C15BE0C00CCF2EB /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
@@ -424,6 +426,7 @@
 			children = (
 				C4F870CD2CEFCC5B00312F8A /* FloooService.swift */,
 				C4875DFF2C149D9000D9BAEB /* AlbumService.swift */,
+				C4CACHE002D7B0000003B9C4F /* StreamCacheManager.swift */,
 				C4875E012C149DDD00D9BAEB /* AuthService.swift */,
 				C4875E032C149F9A00D9BAEB /* APIManager.swift */,
 				C4FE524A2C14E1F70053763A /* UserDefaultsManager.swift */,
@@ -741,6 +744,7 @@
 				C4D7F84F2C7F2C5D00165EFD /* PlaybackService.swift in Sources */,
 				C49134532C15BE0C00CCF2EB /* Strings.swift in Sources */,
 				C4875E002C149D9000D9BAEB /* AlbumService.swift in Sources */,
+				C4CACHE012D7B0000003B9C4F /* StreamCacheManager.swift in Sources */,
 				C456D8FC2F2FF39B002AAB8B /* LyricsLine.swift in Sources */,
 				C429DB322D33C707009F2684 /* DownloadButtonView.swift in Sources */,
 				C4824D232CE8C41F003EAB52 /* Playable.swift in Sources */,

--- a/flo.xcodeproj/project.pbxproj
+++ b/flo.xcodeproj/project.pbxproj
@@ -103,6 +103,8 @@
 		C4824D272CE908DC003EAB52 /* SongsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4824D262CE908DA003EAB52 /* SongsView.swift */; };
 		C4875E002C149D9000D9BAEB /* AlbumService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4875DFF2C149D9000D9BAEB /* AlbumService.swift */; };
 		C4CACHE012D7B0000003B9C4F /* StreamCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4CACHE002D7B0000003B9C4F /* StreamCacheManager.swift */; };
+		0C1A2B3C4D5E6F7A8B9C0D1E /* LibraryCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2A3B4C5D6E7F8A9B0C1D2E /* LibraryCacheManager.swift */; };
+		0D1A2B3C4D5E6F7A8B9C0D1E /* CoverArtCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D2A3B4C5D6E7F8A9B0C1D2E /* CoverArtCacheManager.swift */; };
 		C4875E022C149DDD00D9BAEB /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4875E012C149DDD00D9BAEB /* AuthService.swift */; };
 		C4875E042C149F9A00D9BAEB /* APIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4875E032C149F9A00D9BAEB /* APIManager.swift */; };
 		C49134532C15BE0C00CCF2EB /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = C49134522C15BE0C00CCF2EB /* Strings.swift */; };
@@ -234,6 +236,8 @@
 		C4824D262CE908DA003EAB52 /* SongsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongsView.swift; sourceTree = "<group>"; };
 		C4875DFF2C149D9000D9BAEB /* AlbumService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumService.swift; sourceTree = "<group>"; };
 		C4CACHE002D7B0000003B9C4F /* StreamCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCacheManager.swift; sourceTree = "<group>"; };
+		0C2A3B4C5D6E7F8A9B0C1D2E /* LibraryCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryCacheManager.swift; sourceTree = "<group>"; };
+		0D2A3B4C5D6E7F8A9B0C1D2E /* CoverArtCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoverArtCacheManager.swift; sourceTree = "<group>"; };
 		C4875E012C149DDD00D9BAEB /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		C4875E032C149F9A00D9BAEB /* APIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIManager.swift; sourceTree = "<group>"; };
 		C49134522C15BE0C00CCF2EB /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
@@ -429,6 +433,8 @@
 				C4F870CD2CEFCC5B00312F8A /* FloooService.swift */,
 				C4875DFF2C149D9000D9BAEB /* AlbumService.swift */,
 				C4CACHE002D7B0000003B9C4F /* StreamCacheManager.swift */,
+				0C2A3B4C5D6E7F8A9B0C1D2E /* LibraryCacheManager.swift */,
+				0D2A3B4C5D6E7F8A9B0C1D2E /* CoverArtCacheManager.swift */,
 				C4875E012C149DDD00D9BAEB /* AuthService.swift */,
 				C4875E032C149F9A00D9BAEB /* APIManager.swift */,
 				C4FE524A2C14E1F70053763A /* UserDefaultsManager.swift */,
@@ -749,6 +755,8 @@
 				C49134532C15BE0C00CCF2EB /* Strings.swift in Sources */,
 				C4875E002C149D9000D9BAEB /* AlbumService.swift in Sources */,
 				C4CACHE012D7B0000003B9C4F /* StreamCacheManager.swift in Sources */,
+				0C1A2B3C4D5E6F7A8B9C0D1E /* LibraryCacheManager.swift in Sources */,
+				0D1A2B3C4D5E6F7A8B9C0D1E /* CoverArtCacheManager.swift in Sources */,
 				C456D8FC2F2FF39B002AAB8B /* LyricsLine.swift in Sources */,
 				C429DB322D33C707009F2684 /* DownloadButtonView.swift in Sources */,
 				C4824D232CE8C41F003EAB52 /* Playable.swift in Sources */,

--- a/flo/AlbumViewModel.swift
+++ b/flo/AlbumViewModel.swift
@@ -97,22 +97,76 @@ class AlbumViewModel: ObservableObject {
     }
   }
 
-  func fetchAllSongs() {
-    AlbumService.shared.getAllSongs { result in
-      self.isLoading = true
+  // MARK: - Generic cache helpers
 
+  private enum CacheKey: String {
+    case albums, artists, playlists, songs
+  }
+
+  private func fetchCached<T: Codable>(
+    current: [T],
+    cacheKey: CacheKey,
+    showsLoading: Bool = false,
+    assign: @escaping ([T]) -> Void,
+    request: @escaping (@escaping (Result<[T], Error>) -> Void) -> Void
+  ) {
+    if current.isEmpty,
+      let cached = LibraryCacheManager.shared.load([T].self, forKey: cacheKey.rawValue)
+    {
+      assign(cached)
+    }
+    if showsLoading { isLoading = true }
+    request { result in
       DispatchQueue.main.async {
-        self.isLoading = false
-
+        if showsLoading { self.isLoading = false }
         switch result {
-        case .success(let songs):
-          self.songs = songs
-
+        case .success(let items):
+          assign(items)
+          if !items.isEmpty {
+            DispatchQueue.global(qos: .utility).async {
+              LibraryCacheManager.shared.save(items, forKey: cacheKey.rawValue)
+            }
+          }
         case .failure(let error):
           self.error = error
         }
       }
     }
+  }
+
+  @MainActor
+  private func refreshCached<T: Codable>(
+    cacheKey: CacheKey,
+    assign: @escaping ([T]) -> Void,
+    request: @escaping (@escaping (Result<[T], Error>) -> Void) -> Void
+  ) async {
+    isLoading = true
+    defer { isLoading = false }
+    await withCheckedContinuation { continuation in
+      request { result in
+        DispatchQueue.main.async {
+          switch result {
+          case .success(let items):
+            assign(items)
+            if !items.isEmpty {
+              DispatchQueue.global(qos: .utility).async {
+                LibraryCacheManager.shared.save(items, forKey: cacheKey.rawValue)
+              }
+            }
+          case .failure(let error):
+            self.error = error
+          }
+          continuation.resume()
+        }
+      }
+    }
+  }
+
+  // MARK: - Fetch methods
+
+  func fetchAllSongs() {
+    fetchCached(current: songs, cacheKey: .songs,
+      assign: { self.songs = $0 }, request: AlbumService.shared.getAllSongs)
   }
 
   func getAlbumInfo() {
@@ -275,19 +329,8 @@ class AlbumViewModel: ObservableObject {
   }
 
   func fetchAlbums() {
-    isLoading = true
-    AlbumService.shared.getAlbum { result in
-      DispatchQueue.main.async {
-        self.isLoading = false
-        switch result {
-        case .success(let albums):
-          self.albums = albums
-        case .failure(let error):
-          print("error>>>>", error)
-          self.error = error
-        }
-      }
-    }
+    fetchCached(current: albums, cacheKey: .albums, showsLoading: true,
+      assign: { self.albums = $0 }, request: AlbumService.shared.getAlbum)
   }
 
   func fetchAlbumsByArtist(id: String) {
@@ -326,29 +369,35 @@ class AlbumViewModel: ObservableObject {
   }
 
   func getPlaylists() {
-    AlbumService.shared.getPlaylists { result in
-      DispatchQueue.main.async {
-        switch result {
-        case .success(let playlists):
-          self.playlists = playlists
-        case .failure(let error):
-          self.error = error
-        }
-      }
-    }
+    fetchCached(current: playlists, cacheKey: .playlists,
+      assign: { self.playlists = $0 }, request: AlbumService.shared.getPlaylists)
   }
 
   func getArtists() {
-    AlbumService.shared.getArtists { result in
-      DispatchQueue.main.async {
-        switch result {
-        case .success(let artists):
-          self.artists = artists
-        case .failure(let error):
-          self.error = error
-        }
-      }
-    }
+    fetchCached(current: artists, cacheKey: .artists,
+      assign: { self.artists = $0 }, request: AlbumService.shared.getArtists)
+  }
+
+  // MARK: - Async refresh variants
+
+  @MainActor func refreshAlbums() async {
+    await refreshCached(cacheKey: .albums, assign: { self.albums = $0 },
+      request: AlbumService.shared.getAlbum)
+  }
+
+  @MainActor func refreshArtists() async {
+    await refreshCached(cacheKey: .artists, assign: { self.artists = $0 },
+      request: AlbumService.shared.getArtists)
+  }
+
+  @MainActor func refreshPlaylists() async {
+    await refreshCached(cacheKey: .playlists, assign: { self.playlists = $0 },
+      request: AlbumService.shared.getPlaylists)
+  }
+
+  @MainActor func refreshAllSongs() async {
+    await refreshCached(cacheKey: .songs, assign: { self.songs = $0 },
+      request: AlbumService.shared.getAllSongs)
   }
 
   func fetchDownloadedAlbums() {

--- a/flo/App.swift
+++ b/flo/App.swift
@@ -13,6 +13,10 @@ import UIKit
 struct FloApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
+    init() {
+        StreamCacheManager.shared.reconcile()
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/flo/Artists/ArtistsView.swift
+++ b/flo/Artists/ArtistsView.swift
@@ -54,6 +54,9 @@ struct ArtistsView: View {
         }.padding(.bottom, 100)
       }
       .navigationTitle("Artists")
+      .refreshable {
+        await viewModel.refreshArtists()
+      }
       .searchable(
         text: $searchArtist, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search"
       )

--- a/flo/FloooViewModel.swift
+++ b/flo/FloooViewModel.swift
@@ -13,6 +13,7 @@ class FloooViewModel: ObservableObject {
   @Published var downloadedSongs: Int = 0
 
   @Published var localDirectorySize: String = "0 MB"
+  @Published var streamCacheSize: String = "0 MB"
 
   @Published var stats: Stats?
   @Published var totalPlay: Int = 0
@@ -60,9 +61,11 @@ class FloooViewModel: ObservableObject {
     Task {
       do {
         let calculateDirectorySize = try await LocalFileManager.shared.calculateDirectorySize()
+        let cacheSize = await StreamCacheManager.shared.calculateCacheSize()
 
         await MainActor.run {
           self.localDirectorySize = calculateDirectorySize
+          self.streamCacheSize = bytesToMBOrGB(cacheSize)
         }
       } catch {
         print("Error: \(error)")

--- a/flo/Navigation/CachedSongsView.swift
+++ b/flo/Navigation/CachedSongsView.swift
@@ -58,7 +58,7 @@ struct CachedSongsView: View {
             Divider()
           }
           .onTapGesture {
-            let cached = CachedSongsPlayable(songs: songs)
+            let cached = SongCollection(id: "cached-songs", name: "Cached", songs: songs)
             playerViewModel.playBySong(idx: idx, item: cached, isFromLocal: true)
           }
           .frame(maxWidth: .infinity, alignment: .leading)

--- a/flo/Navigation/CachedSongsView.swift
+++ b/flo/Navigation/CachedSongsView.swift
@@ -1,0 +1,73 @@
+//
+//  CachedSongsView.swift
+//  flo
+//
+
+import NukeUI
+import SwiftUI
+
+struct CachedSongsView: View {
+  @ObservedObject var viewModel: AlbumViewModel
+  @EnvironmentObject private var playerViewModel: PlayerViewModel
+
+  let songs: [Song]
+
+  var body: some View {
+    ScrollView {
+      LazyVStack {
+        ForEach(Array(songs.enumerated()), id: \.element.id) { idx, song in
+          VStack {
+            HStack {
+              LazyImage(url: URL(string: viewModel.getAlbumCoverArt(id: song.albumId))) { state in
+                if let image = state.image {
+                  image
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 60, height: 60)
+                    .clipShape(
+                      RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    )
+                } else {
+                  Color("PlayerColor").frame(width: 60, height: 60)
+                    .cornerRadius(5)
+                }
+              }
+
+              VStack(alignment: .leading) {
+                Text(song.title)
+                  .customFont(.headline)
+                  .multilineTextAlignment(.leading)
+                  .lineLimit(2)
+                  .padding(.bottom, 3)
+
+                Text(song.artist)
+                  .customFont(.subheadline)
+                  .foregroundColor(.gray)
+                  .lineLimit(2)
+                  .multilineTextAlignment(.leading)
+              }
+              .padding(.horizontal, 10)
+
+              Spacer()
+
+              Text(timeString(for: song.duration)).customFont(.caption1)
+            }
+            .padding(.horizontal)
+            .background(Color(UIColor.systemBackground))
+
+            Divider()
+          }
+          .onTapGesture {
+            let cached = CachedSongsPlayable(songs: songs)
+            playerViewModel.playBySong(idx: idx, item: cached, isFromLocal: true)
+          }
+          .frame(maxWidth: .infinity, alignment: .leading)
+        }
+      }
+      .padding(.top, 10)
+      .padding(
+        .bottom, playerViewModel.hasNowPlaying() && !playerViewModel.shouldHidePlayer ? 100 : 0)
+    }
+    .navigationTitle("Cached")
+  }
+}

--- a/flo/Navigation/DownloadsView.swift
+++ b/flo/Navigation/DownloadsView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct DownloadsView: View {
   @State private var searchAlbum = ""
+  @State private var cachedSongs: [Song] = []
 
   @ObservedObject var viewModel: AlbumViewModel
 
@@ -32,7 +33,7 @@ struct DownloadsView: View {
   var body: some View {
     NavigationStack {
       ScrollView {
-        if viewModel.downloadedAlbums.isEmpty {
+        if viewModel.downloadedAlbums.isEmpty && cachedSongs.isEmpty {
           VStack(alignment: .leading) {
             Image("Downloads").resizable().aspectRatio(contentMode: .fit).frame(width: 300)
               .padding()
@@ -50,6 +51,35 @@ struct DownloadsView: View {
 
             }.padding(.horizontal, 20).foregroundColor(.accent)
           }
+        }
+
+        // Cached songs section
+        if !cachedSongs.isEmpty {
+          NavigationLink {
+            CachedSongsView(viewModel: viewModel, songs: cachedSongs)
+          } label: {
+            HStack {
+              Image(systemName: "music.note.list")
+                .font(.title3)
+                .foregroundColor(.accentColor)
+                .frame(width: 40)
+              VStack(alignment: .leading) {
+                Text("Cached")
+                  .customFont(.headline)
+                Text("\(cachedSongs.count) songs")
+                  .customFont(.caption1)
+                  .foregroundColor(.gray)
+              }
+              Spacer()
+              Image(systemName: "chevron.right")
+                .foregroundColor(.gray)
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+          }
+          .buttonStyle(.plain)
+
+          Divider().padding(.horizontal)
         }
 
         LazyVGrid(columns: columns, spacing: 20) {
@@ -71,6 +101,9 @@ struct DownloadsView: View {
             placement: .navigationBarDrawer(displayMode: .always),
             prompt: "Search"
           )
+      }
+      .onAppear {
+        cachedSongs = StreamCacheManager.shared.getCachedSongs()
       }
     }
   }

--- a/flo/Navigation/LibraryView.swift
+++ b/flo/Navigation/LibraryView.swift
@@ -184,6 +184,11 @@ struct LibraryView: View {
         }
       }
       .navigationTitle("Library")
+      .refreshable {
+        await viewModel.refreshAlbums()
+        await viewModel.refreshArtists()
+        await viewModel.refreshPlaylists()
+      }
     }
   }
 }

--- a/flo/Navigation/PreferencesView.swift
+++ b/flo/Navigation/PreferencesView.swift
@@ -116,6 +116,8 @@ struct PreferencesView: View {
 
   @State private var experimentalMaxBitrate = UserDefaultsManager.maxBitRate
   @State private var experimentalPlayerBackground = UserDefaultsManager.playerBackground
+  @State private var experimentalStreamCacheSize = UserDefaultsManager.streamCacheMaxSize
+  @State private var clearStreamCacheAlert = false
   @State private var experimentalLRCLIBIntegration = UserDefaultsManager.LRCLIBServerURL
   @State private var customLRCLIBServer = ""
 
@@ -190,6 +192,41 @@ struct PreferencesView: View {
             Spacer()
             Text(floooViewModel.localDirectorySize)
           }
+
+          HStack {
+            Text("Streaming cache")
+            Spacer()
+            Text(floooViewModel.streamCacheSize)
+          }
+
+          Picker("Cache limit", selection: $experimentalStreamCacheSize) {
+            Text("Off").tag(Int64(0))
+            Text("500 MB").tag(Int64(524_288_000))
+            Text("1 GB").tag(Int64(1_073_741_824))
+            Text("2 GB").tag(Int64(2_147_483_648))
+            Text("5 GB").tag(Int64(5_368_709_120))
+          }
+          .onChange(of: experimentalStreamCacheSize) { value in
+            UserDefaultsManager.streamCacheMaxSize = value
+          }
+
+          Button(action: {
+            self.clearStreamCacheAlert.toggle()
+          }) {
+            Text("Clear streaming cache")
+          }.alert(
+            "Clear Streaming Cache", isPresented: $clearStreamCacheAlert,
+            actions: {
+              Button(
+                "Clear", role: .destructive,
+                action: {
+                  StreamCacheManager.shared.clearCache()
+                  floooViewModel.getLocalStorageInformation()
+                })
+            },
+            message: {
+              Text("This will delete all cached streamed songs. Downloads are not affected.")
+            })
 
           Button(
             role: .destructive,

--- a/flo/PlayerViewModel.swift
+++ b/flo/PlayerViewModel.swift
@@ -314,7 +314,8 @@ class PlayerViewModel: ObservableObject {
           let nextId = self.queue[nextIdx].id, !nextId.isEmpty
         {
           StreamCacheManager.shared.cacheSong(
-            mediaFileId: nextId, originalSuffix: self.queue[nextIdx].suffix)
+            mediaFileId: nextId, originalSuffix: self.queue[nextIdx].suffix,
+            from: self.queue[nextIdx])
         }
       }
 

--- a/flo/PlayerViewModel.swift
+++ b/flo/PlayerViewModel.swift
@@ -52,6 +52,7 @@ class PlayerViewModel: ObservableObject {
   private var routeChangeObservation = Set<AnyCancellable>()
 
   private var scrobbleThreshold = 0.5
+  private var hasTriggeredCache: Bool = false
 
   var nowPlaying: QueueEntity {
     return self.queue[self.activeQueueIdx]
@@ -196,6 +197,9 @@ class PlayerViewModel: ObservableObject {
 
     self.shouldHidePlayer = false
     self.isLocallySaved = false
+    self.hasTriggeredCache = false
+
+    StreamCacheManager.shared.cancelAllInFlight()
 
     try? AVAudioSession.sharedInstance().setActive(true)
 
@@ -205,7 +209,10 @@ class PlayerViewModel: ObservableObject {
       player?.removeTimeObserver(timeObserverToken)
     }
 
-    let streamUrl = AlbumService.shared.getStreamUrl(id: self.nowPlaying.id ?? "")
+    let songId = self.nowPlaying.id ?? ""
+    StreamCacheManager.shared.setCurrentlyPlaying(mediaFileId: songId)
+
+    let streamUrl = AlbumService.shared.getStreamUrl(id: songId)
 
     guard let audioURL = URL(string: streamUrl), !streamUrl.isEmpty else {
       self.isMediaLoading = false
@@ -298,6 +305,16 @@ class PlayerViewModel: ObservableObject {
           FloooViewModel.shared.scrobble(submission: true, nowPlaying: self.nowPlaying)
 
           self.isLocallySaved = true
+        }
+      }
+
+      if !self.hasTriggeredCache && currentTime >= 10.0 && !self.isLiveRadio {
+        self.hasTriggeredCache = true
+        if let nextIdx = self.nextQueueIdxForPreCache(),
+          let nextId = self.queue[nextIdx].id, !nextId.isEmpty
+        {
+          StreamCacheManager.shared.cacheSong(
+            mediaFileId: nextId, originalSuffix: self.queue[nextIdx].suffix)
         }
       }
 
@@ -645,6 +662,22 @@ class PlayerViewModel: ObservableObject {
     }
 
     UserDefaultsManager.queueActiveIdx = self.activeQueueIdx
+  }
+
+  private func nextQueueIdxForPreCache() -> Int? {
+    if queue.count <= 1 { return nil }
+
+    if playbackMode == PlaybackMode.repeatOnce {
+      return nil
+    }
+
+    if playbackMode == PlaybackMode.repeatAlbum {
+      return activeQueueIdx + 1 >= queue.count ? 0 : activeQueueIdx + 1
+    }
+
+    let nextIdx = activeQueueIdx + 1
+    guard nextIdx < queue.count else { return nil }
+    return nextIdx
   }
 
   func destroyPlayerAndQueue() {

--- a/flo/PlaylistView.swift
+++ b/flo/PlaylistView.swift
@@ -79,6 +79,9 @@ struct PlaylistView: View {
         DownloadQueueView().environmentObject(downloadViewModel)
       }
       .navigationTitle("Playlists")
+      .refreshable {
+        await viewModel.refreshPlaylists()
+      }
       .searchable(
         text: $searchPlaylist, placement: .navigationBarDrawer(displayMode: .always),
         prompt: "Search")

--- a/flo/Resources/Localizable.xcstrings
+++ b/flo/Resources/Localizable.xcstrings
@@ -127,6 +127,9 @@
         }
       }
     },
+    "%lld songs" : {
+
+    },
     "•" : {
       "localizations" : {
         "en" : {
@@ -372,6 +375,9 @@
       }
     },
     "Cache limit" : {
+
+    },
+    "Cached" : {
 
     },
     "Cancel" : {

--- a/flo/Resources/Localizable.xcstrings
+++ b/flo/Resources/Localizable.xcstrings
@@ -159,6 +159,18 @@
         }
       }
     },
+    "1 GB" : {
+
+    },
+    "2 GB" : {
+
+    },
+    "5 GB" : {
+
+    },
+    "500 MB" : {
+
+    },
     "About flo" : {
       "localizations" : {
         "en" : {
@@ -359,6 +371,9 @@
         }
       }
     },
+    "Cache limit" : {
+
+    },
     "Cancel" : {
       "localizations" : {
         "en" : {
@@ -374,6 +389,9 @@
           }
         }
       }
+    },
+    "Clear" : {
+
     },
     "Clear Downloaded/Canceled Queue" : {
       "localizations" : {
@@ -400,6 +418,12 @@
           }
         }
       }
+    },
+    "Clear streaming cache" : {
+
+    },
+    "Clear Streaming Cache" : {
+
     },
     "Continue" : {
       "localizations" : {
@@ -1024,6 +1048,9 @@
         }
       }
     },
+    "Off" : {
+
+    },
     "OK" : {
       "localizations" : {
         "en" : {
@@ -1507,6 +1534,9 @@
         }
       }
     },
+    "Streaming cache" : {
+
+    },
     "Subsonic Version" : {
       "localizations" : {
         "en" : {
@@ -1622,6 +1652,9 @@
           }
         }
       }
+    },
+    "This will delete all cached streamed songs. Downloads are not affected." : {
+
     },
     "To change this, please do so via the Navidrome Web UI" : {
       "localizations" : {

--- a/flo/Shared/Models/Playable.swift
+++ b/flo/Shared/Models/Playable.swift
@@ -11,3 +11,10 @@ protocol Playable {
   var songs: [Song] { get set }
   var artist: String { get }
 }
+
+struct CachedSongsPlayable: Playable {
+  let id: String = "cached-songs"
+  let name: String = "Cached"
+  var songs: [Song]
+  let artist: String = ""
+}

--- a/flo/Shared/Models/Playable.swift
+++ b/flo/Shared/Models/Playable.swift
@@ -12,9 +12,9 @@ protocol Playable {
   var artist: String { get }
 }
 
-struct CachedSongsPlayable: Playable {
-  let id: String = "cached-songs"
-  let name: String = "Cached"
+struct SongCollection: Playable {
+  let id: String
+  let name: String
   var songs: [Song]
   let artist: String = ""
 }

--- a/flo/Shared/Models/Song.swift
+++ b/flo/Shared/Models/Song.swift
@@ -113,6 +113,21 @@ struct Song: Codable, Identifiable, Hashable {
     self.mediaFileId = mediaFileId
   }
 
+  init(from cache: CacheEntity) {
+    self.id = cache.mediaFileId ?? ""
+    self.title = cache.title ?? "Unknown"
+    self.artist = cache.artistName ?? "Unknown"
+    self.albumId = cache.albumId ?? ""
+    self.albumName = cache.albumName ?? ""
+    self.trackNumber = 0
+    self.discNumber = 0
+    self.bitRate = Int(cache.bitRate)
+    self.sampleRate = Int(cache.sampleRate)
+    self.suffix = cache.suffix ?? ""
+    self.duration = cache.duration
+    self.mediaFileId = cache.mediaFileId ?? ""
+  }
+
   #if os(iOS)
     init(from song: SongEntity) {
       self.id = song.id ?? ""

--- a/flo/Shared/Models/Song.swift
+++ b/flo/Shared/Models/Song.swift
@@ -113,6 +113,7 @@ struct Song: Codable, Identifiable, Hashable {
     self.mediaFileId = mediaFileId
   }
 
+  #if os(iOS)
   init(from cache: CacheEntity) {
     self.id = cache.mediaFileId ?? ""
     self.title = cache.title ?? "Unknown"
@@ -127,6 +128,7 @@ struct Song: Codable, Identifiable, Hashable {
     self.duration = cache.duration
     self.mediaFileId = cache.mediaFileId ?? ""
   }
+  #endif
 
   #if os(iOS)
     init(from song: SongEntity) {

--- a/flo/Shared/Services/AlbumService.swift
+++ b/flo/Shared/Services/AlbumService.swift
@@ -243,6 +243,8 @@ class AlbumService {
       return LocalFileManager.shared.fileURL(for: contextTarget)?.path ?? ""
     } else if LocalFileManager.shared.fileExists(fileName: anotherTarget) {
       return LocalFileManager.shared.fileURL(for: anotherTarget)?.path ?? ""
+    } else if let cached = CoverArtCacheManager.shared.cachedFilePath(albumId: albumId) {
+      return cached
     } else {
       return
         "\(UserDefaultsManager.serverBaseURL)\(API.SubsonicEndpoint.coverArt)\(AuthService.shared.getCreds(key: "subsonicToken"))&id=al-\(albumId)&size=300"

--- a/flo/Shared/Services/AlbumService.swift
+++ b/flo/Shared/Services/AlbumService.swift
@@ -11,7 +11,7 @@ import Foundation
 class AlbumService {
   static let shared = AlbumService()
 
-  private func buildRemoteStreamUrl(id: String) -> String {
+  func buildRemoteStreamUrl(id: String) -> String {
     let maxBitrate = UserDefaultsManager.maxBitRate
 
     let format =
@@ -32,6 +32,10 @@ class AlbumService {
       let fileUrl = LocalFileManager.shared.fileURL(for: localPath)
     {
       return fileUrl.absoluteString
+    }
+
+    if let cachedUrl = StreamCacheManager.shared.cachedFileURL(mediaFileId: id) {
+      return cachedUrl.absoluteString
     }
 
     return buildRemoteStreamUrl(id: id)

--- a/flo/Shared/Services/CoreDataManager.swift
+++ b/flo/Shared/Services/CoreDataManager.swift
@@ -202,7 +202,7 @@ class CoreDataManager: ObservableObject {
   }
 
   func clearEverything() {
-    let entities = ["QueueEntity", "SongEntity", "PlaylistEntity"]
+    let entities = ["QueueEntity", "SongEntity", "PlaylistEntity", "CacheEntity"]
 
     for entity in entities {
       let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entity)

--- a/flo/Shared/Services/CoverArtCacheManager.swift
+++ b/flo/Shared/Services/CoverArtCacheManager.swift
@@ -1,0 +1,71 @@
+//
+//  CoverArtCacheManager.swift
+//  flo
+//
+
+import Foundation
+
+class CoverArtCacheManager {
+  static let shared = CoverArtCacheManager()
+
+  private let fileManager = FileManager.default
+  private let cacheDirectory: URL?
+  private var inFlightIds: Set<String> = []
+  private let syncQueue = DispatchQueue(label: "net.faultables.flo.coverartcache")
+
+  private init() {
+    self.cacheDirectory =
+      fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first?
+      .appendingPathComponent("CoverArtCache")
+
+    if let dir = cacheDirectory, !fileManager.fileExists(atPath: dir.path) {
+      try? fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+    }
+  }
+
+  func cachedFilePath(albumId: String) -> String? {
+    guard let dir = cacheDirectory else { return nil }
+    let file = dir.appendingPathComponent("\(albumId).img")
+    guard fileManager.fileExists(atPath: file.path) else { return nil }
+    return file.path
+  }
+
+  func cacheIfNeeded(albumId: String) {
+    guard !albumId.isEmpty else { return }
+
+    var shouldDownload = false
+    syncQueue.sync {
+      if cachedFilePath(albumId: albumId) == nil && !inFlightIds.contains(albumId) {
+        inFlightIds.insert(albumId)
+        shouldDownload = true
+      }
+    }
+    guard shouldDownload else { return }
+
+    let params: [String: Any] = ["id": "al-\(albumId)", "size": 300]
+    APIManager.shared.SubsonicEndpointDownload(
+      endpoint: API.SubsonicEndpoint.coverArt, parameters: params
+    ) { [weak self] result in
+      guard let self = self else { return }
+      switch result {
+      case .success(let tempFile):
+        if let dir = self.cacheDirectory {
+          let target = dir.appendingPathComponent("\(albumId).img")
+          try? self.fileManager.removeItem(at: target)
+          try? self.fileManager.moveItem(at: tempFile, to: target)
+        }
+      case .failure:
+        break
+      }
+      self.syncQueue.sync {
+        self.inFlightIds.remove(albumId)
+      }
+    }
+  }
+
+  func clearCache() {
+    guard let dir = cacheDirectory, fileManager.fileExists(atPath: dir.path) else { return }
+    try? fileManager.removeItem(at: dir)
+    try? fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+  }
+}

--- a/flo/Shared/Services/LibraryCacheManager.swift
+++ b/flo/Shared/Services/LibraryCacheManager.swift
@@ -1,0 +1,43 @@
+//
+//  LibraryCacheManager.swift
+//  flo
+//
+
+import Foundation
+
+class LibraryCacheManager {
+  static let shared = LibraryCacheManager()
+
+  private let fileManager = FileManager.default
+  private let cacheDirectory: URL?
+
+  private init() {
+    self.cacheDirectory =
+      fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first?
+      .appendingPathComponent("LibraryCache")
+
+    if let dir = cacheDirectory, !fileManager.fileExists(atPath: dir.path) {
+      try? fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+    }
+  }
+
+  func save<T: Encodable>(_ items: T, forKey key: String) {
+    guard let dir = cacheDirectory else { return }
+    let file = dir.appendingPathComponent("\(key).json")
+    guard let data = try? JSONEncoder().encode(items) else { return }
+    try? data.write(to: file, options: .atomic)
+  }
+
+  func load<T: Decodable>(_ type: T.Type, forKey key: String) -> T? {
+    guard let dir = cacheDirectory else { return nil }
+    let file = dir.appendingPathComponent("\(key).json")
+    guard let data = try? Data(contentsOf: file) else { return nil }
+    return try? JSONDecoder().decode(T.self, from: data)
+  }
+
+  func clearCache() {
+    guard let dir = cacheDirectory, fileManager.fileExists(atPath: dir.path) else { return }
+    try? fileManager.removeItem(at: dir)
+    try? fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+  }
+}

--- a/flo/Shared/Services/StreamCacheManager.swift
+++ b/flo/Shared/Services/StreamCacheManager.swift
@@ -56,7 +56,7 @@ class StreamCacheManager {
     return fileURL
   }
 
-  func cacheSong(mediaFileId: String, originalSuffix: String? = nil) {
+  func cacheSong(mediaFileId: String, originalSuffix: String? = nil, from queueItem: QueueEntity? = nil) {
     guard UserDefaultsManager.streamCacheMaxSize > 0 else { return }
     guard !mediaFileId.isEmpty else { return }
 
@@ -94,6 +94,18 @@ class StreamCacheManager {
     entity.cachedAt = Date()
     entity.lastAccessedAt = Date()
     entity.fileSize = 0
+
+    // Store song metadata for offline browsing
+    if let q = queueItem {
+      entity.title = q.songName
+      entity.artistName = q.artistName
+      entity.albumId = q.albumId
+      entity.albumName = q.albumName
+      entity.duration = q.duration
+      entity.bitRate = q.bitRate
+      entity.sampleRate = q.sampleRate
+    }
+
     CoreDataManager.shared.saveRecord()
 
     let params: [String: Any] = [
@@ -156,6 +168,22 @@ class StreamCacheManager {
     }
 
     syncQueue.sync { self.inFlightDownloads[key] = request }
+  }
+
+  func getCachedSongs() -> [Song] {
+    let sortDescriptor = NSSortDescriptor(key: "lastAccessedAt", ascending: false)
+    let records = CoreDataManager.shared.getRecordsByEntity(
+      entity: CacheEntity.self, sortDescriptors: [sortDescriptor])
+
+    // Deduplicate by mediaFileId (keep most recent per song)
+    var seen = Set<String>()
+    return records
+      .filter { $0.state == "ready" && $0.title != nil }
+      .filter { record in
+        guard let id = record.mediaFileId else { return false }
+        return seen.insert(id).inserted
+      }
+      .map { Song(from: $0) }
   }
 
   func setCurrentlyPlaying(mediaFileId: String) {

--- a/flo/Shared/Services/StreamCacheManager.swift
+++ b/flo/Shared/Services/StreamCacheManager.swift
@@ -1,0 +1,303 @@
+//
+//  StreamCacheManager.swift
+//  flo
+//
+
+import Alamofire
+import CoreData
+import Foundation
+
+class StreamCacheManager {
+  static let shared = StreamCacheManager()
+
+  private let fileManager = FileManager.default
+  private let cacheDirectory: URL?
+  private let syncQueue = DispatchQueue(label: "net.faultables.flo.streamcache")
+  private var inFlightDownloads: [String: DownloadRequest] = [:]
+  private var inFlightProgress: [String: Double] = [:]
+  private var inFlightKeys: Set<String> = []
+  private var currentlyPlayingSongId: String?
+
+  private init() {
+    self.cacheDirectory =
+      fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first?
+      .appendingPathComponent("StreamCache")
+
+    if let dir = cacheDirectory, !fileManager.fileExists(atPath: dir.path) {
+      try? fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+    }
+  }
+
+  // MARK: - Public API
+
+  func cachedFileURL(mediaFileId: String) -> URL? {
+    let bitrate = UserDefaultsManager.maxBitRate
+    let key = cacheKey(mediaFileId: mediaFileId, bitrate: bitrate)
+
+    guard
+      let record = CoreDataManager.shared.getRecordByKey(
+        entity: CacheEntity.self, key: \CacheEntity.cacheKey, value: key, limit: 1
+      ).first,
+      record.state == "ready",
+      let filePath = record.filePath,
+      let dir = cacheDirectory
+    else { return nil }
+
+    let fileURL = dir.appendingPathComponent(filePath)
+    guard fileManager.fileExists(atPath: fileURL.path) else {
+      CoreDataManager.shared.deleteRecordByKey(
+        entity: CacheEntity.self, key: \CacheEntity.cacheKey, value: key)
+      return nil
+    }
+
+    record.lastAccessedAt = Date()
+    CoreDataManager.shared.saveRecord()
+
+    return fileURL
+  }
+
+  func cacheSong(mediaFileId: String, originalSuffix: String? = nil) {
+    guard UserDefaultsManager.streamCacheMaxSize > 0 else { return }
+    guard !mediaFileId.isEmpty else { return }
+
+    let bitrate = UserDefaultsManager.maxBitRate
+    let key = cacheKey(mediaFileId: mediaFileId, bitrate: bitrate)
+
+    // Register in-flight atomically — prevents duplicate downloads
+    let didRegister: Bool = syncQueue.sync {
+      guard !inFlightKeys.contains(key) else { return false }
+      inFlightKeys.insert(key)
+      return true
+    }
+    guard didRegister else { return }
+
+    // Already cached?
+    let existing = CoreDataManager.shared.getRecordByKey(
+      entity: CacheEntity.self, key: \CacheEntity.cacheKey, value: key, limit: 1)
+    if !existing.isEmpty {
+      syncQueue.async { self.inFlightKeys.remove(key) }
+      return
+    }
+
+    let format =
+      bitrate == TranscodingSettings.sourceBitRate
+      ? TranscodingSettings.sourceFormat : TranscodingSettings.targetFormat
+    let suffix = format == "raw" ? (originalSuffix ?? "raw") : format
+
+    // Create CacheEntity with downloading state
+    let entity = CacheEntity(context: CoreDataManager.shared.viewContext)
+    entity.cacheKey = key
+    entity.mediaFileId = mediaFileId
+    entity.filePath = "\(key).\(suffix)"
+    entity.suffix = suffix
+    entity.state = "downloading"
+    entity.cachedAt = Date()
+    entity.lastAccessedAt = Date()
+    entity.fileSize = 0
+    CoreDataManager.shared.saveRecord()
+
+    let params: [String: Any] = [
+      "id": mediaFileId,
+      "maxBitRate": bitrate,
+      "format": format,
+    ]
+
+    let progressUpdate: (Double) -> Void = { [weak self] progress in
+      self?.syncQueue.async { self?.inFlightProgress[key] = progress / 100.0 }
+    }
+
+    let request = APIManager.shared.SubsonicEndpointDownloadNew(
+      endpoint: API.SubsonicEndpoint.stream, parameters: params, progressUpdate: progressUpdate
+    ) { [weak self] result in
+      guard let self = self else { return }
+
+      self.syncQueue.async {
+        self.inFlightDownloads.removeValue(forKey: key)
+        self.inFlightProgress.removeValue(forKey: key)
+        self.inFlightKeys.remove(key)
+      }
+
+      switch result {
+      case .success(let tempFile):
+        guard let dir = self.cacheDirectory else {
+          self.removeCacheRecord(key: key)
+          return
+        }
+
+        let target = dir.appendingPathComponent("\(key).\(suffix)")
+
+        LocalFileManager.shared.moveFile(source: tempFile, target: target) { moveResult in
+          switch moveResult {
+          case .success:
+            let fileSize =
+              (try? self.fileManager.attributesOfItem(atPath: target.path)[.size] as? Int64) ?? 0
+
+            let records = CoreDataManager.shared.getRecordByKey(
+              entity: CacheEntity.self, key: \CacheEntity.cacheKey, value: key, limit: 1)
+            if let record = records.first {
+              record.state = "ready"
+              record.fileSize = fileSize
+              CoreDataManager.shared.saveRecord()
+            }
+
+            self.evictIfNeeded()
+
+          case .failure:
+            self.removeCacheRecord(key: key)
+          }
+        }
+
+      case .failure(let error):
+        if let afError = error.asAFError, case .explicitlyCancelled = afError {
+          // Cancelled — clean up
+        }
+        self.removeCacheRecord(key: key)
+      }
+    }
+
+    syncQueue.sync { self.inFlightDownloads[key] = request }
+  }
+
+  func setCurrentlyPlaying(mediaFileId: String) {
+    syncQueue.async { self.currentlyPlayingSongId = mediaFileId }
+  }
+
+  func cancelAllInFlight() {
+    let keysToClean: [String] = syncQueue.sync {
+      let keys = Array(inFlightDownloads.keys)
+      for (_, request) in inFlightDownloads {
+        request.cancel()
+      }
+      inFlightDownloads.removeAll()
+      inFlightProgress.removeAll()
+      inFlightKeys.removeAll()
+      return keys
+    }
+
+    for key in keysToClean {
+      removeCacheRecord(key: key)
+    }
+  }
+
+  func clearCache() {
+    // Cancel all downloads
+    syncQueue.sync {
+      for (_, request) in inFlightDownloads { request.cancel() }
+      inFlightDownloads.removeAll()
+      inFlightProgress.removeAll()
+      inFlightKeys.removeAll()
+    }
+
+    // Delete all files
+    if let dir = cacheDirectory, fileManager.fileExists(atPath: dir.path) {
+      try? fileManager.removeItem(at: dir)
+      try? fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+    }
+
+    // Delete all CacheEntity records
+    let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "CacheEntity")
+    let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+    try? CoreDataManager.shared.viewContext.execute(deleteRequest)
+    try? CoreDataManager.shared.viewContext.save()
+  }
+
+  func calculateCacheSize() async -> Int64 {
+    return await MainActor.run {
+      let records = CoreDataManager.shared.getRecordsByEntity(entity: CacheEntity.self)
+      return records.filter { $0.state == "ready" }.reduce(0) { $0 + $1.fileSize }
+    }
+  }
+
+  func reconcile() {
+    // Cancel any active downloads first to prevent races
+    syncQueue.sync {
+      for (_, request) in inFlightDownloads { request.cancel() }
+      inFlightDownloads.removeAll()
+      inFlightProgress.removeAll()
+      inFlightKeys.removeAll()
+    }
+
+    let records = CoreDataManager.shared.getRecordsByEntity(entity: CacheEntity.self)
+
+    for record in records {
+      if record.state == "downloading" {
+        if let filePath = record.filePath, let dir = cacheDirectory {
+          let fileURL = dir.appendingPathComponent(filePath)
+          try? fileManager.removeItem(at: fileURL)
+        }
+        CoreDataManager.shared.viewContext.delete(record)
+        continue
+      }
+
+      if let filePath = record.filePath, let dir = cacheDirectory {
+        let fileURL = dir.appendingPathComponent(filePath)
+        if !fileManager.fileExists(atPath: fileURL.path) {
+          CoreDataManager.shared.viewContext.delete(record)
+        }
+      } else {
+        CoreDataManager.shared.viewContext.delete(record)
+      }
+    }
+
+    CoreDataManager.shared.saveRecord()
+
+    // Re-fetch surviving records for orphan file cleanup
+    let survivingRecords = CoreDataManager.shared.getRecordsByEntity(entity: CacheEntity.self)
+    let knownFiles = Set(survivingRecords.compactMap { $0.filePath })
+
+    if let dir = cacheDirectory,
+      let files = try? fileManager.contentsOfDirectory(
+        at: dir, includingPropertiesForKeys: nil)
+    {
+      for file in files {
+        if !knownFiles.contains(file.lastPathComponent) {
+          try? fileManager.removeItem(at: file)
+        }
+      }
+    }
+  }
+
+  // MARK: - Private
+
+  private func cacheKey(mediaFileId: String, bitrate: String) -> String {
+    return "\(mediaFileId)_\(bitrate)"
+  }
+
+  private func removeCacheRecord(key: String) {
+    CoreDataManager.shared.deleteRecordByKey(
+      entity: CacheEntity.self, key: \CacheEntity.cacheKey, value: key)
+  }
+
+  private func evictIfNeeded() {
+    let maxSize = UserDefaultsManager.streamCacheMaxSize
+    guard maxSize > 0 else { return }
+
+    let sortDescriptor = NSSortDescriptor(key: "lastAccessedAt", ascending: true)
+    let records = CoreDataManager.shared.getRecordsByEntity(
+      entity: CacheEntity.self, sortDescriptors: [sortDescriptor])
+
+    let totalSize = records.filter { $0.state == "ready" }.reduce(Int64(0)) { $0 + $1.fileSize }
+    guard totalSize > maxSize else { return }
+
+    var currentSize = totalSize
+    let currentlyPlaying: String? = syncQueue.sync { currentlyPlayingSongId }
+
+    for record in records where record.state == "ready" {
+      guard currentSize > maxSize else { break }
+
+      if let playing = currentlyPlaying, record.mediaFileId == playing { continue }
+
+      let size = record.fileSize
+
+      if let filePath = record.filePath, let dir = cacheDirectory {
+        let fileURL = dir.appendingPathComponent(filePath)
+        try? fileManager.removeItem(at: fileURL)
+      }
+
+      CoreDataManager.shared.viewContext.delete(record)
+      currentSize -= size
+    }
+
+    CoreDataManager.shared.saveRecord()
+  }
+}

--- a/flo/Shared/Services/UserDefaultsManager.swift
+++ b/flo/Shared/Services/UserDefaultsManager.swift
@@ -119,6 +119,16 @@ class UserDefaultsManager {
     }
   }
 
+  static var streamCacheMaxSize: Int64 {
+    get {
+      let stored = UserDefaults.standard.object(forKey: UserDefaultsKeys.streamCacheMaxSize)
+      return (stored as? Int64) ?? 0  // default off
+    }
+    set {
+      UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.streamCacheMaxSize)
+    }
+  }
+
   static var floPlus: Bool {
     get {
       return UserDefaults.standard.bool(forKey: UserDefaultsKeys.floPlus)

--- a/flo/Shared/Utils/Constants.swift
+++ b/flo/Shared/Utils/Constants.swift
@@ -58,6 +58,7 @@ enum UserDefaultsKeys {
   static let saveLoginInfo = "saveLoginInfo"
   static let LRCLIBServerURL = "LRCLIBServerURL"
   static let floPlus = "floPlus"
+  static let streamCacheMaxSize = "streamCacheMaxSize"
 }
 
 enum KeychainKeys {

--- a/flo/SongsView.swift
+++ b/flo/SongsView.swift
@@ -86,6 +86,9 @@ struct SongsView: View {
       .padding(.top, 10)
       .padding(.bottom, 100)
       .navigationTitle("Songs")
+      .refreshable {
+        await viewModel.refreshAllSongs()
+      }
       .searchable(
         text: $searchSong,
         placement: .navigationBarDrawer(displayMode: .always),

--- a/flo/flo.xcdatamodeld/flo.xcdatamodel/contents
+++ b/flo/flo.xcdatamodeld/flo.xcdatamodel/contents
@@ -37,6 +37,21 @@
         <attribute name="songName" optional="YES" attributeType="String"/>
         <attribute name="suffix" optional="YES" attributeType="String"/>
     </entity>
+    <entity name="CacheEntity" representedClassName="CacheEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="cacheKey" attributeType="String"/>
+        <attribute name="cachedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="fileSize" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="lastAccessedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="mediaFileId" optional="YES" attributeType="String"/>
+        <attribute name="filePath" optional="YES" attributeType="String"/>
+        <attribute name="state" optional="YES" attributeType="String"/>
+        <attribute name="suffix" optional="YES" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="cacheKey"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
     <entity name="SongEntity" representedClassName="SongEntity" syncable="YES" codeGenerationType="class">
         <attribute name="albumId" attributeType="String"/>
         <attribute name="albumName" optional="YES" attributeType="String"/>

--- a/flo/flo.xcdatamodeld/flo.xcdatamodel/contents
+++ b/flo/flo.xcdatamodeld/flo.xcdatamodel/contents
@@ -38,14 +38,21 @@
         <attribute name="suffix" optional="YES" attributeType="String"/>
     </entity>
     <entity name="CacheEntity" representedClassName="CacheEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="albumId" optional="YES" attributeType="String"/>
+        <attribute name="albumName" optional="YES" attributeType="String"/>
+        <attribute name="artistName" optional="YES" attributeType="String"/>
+        <attribute name="bitRate" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="cacheKey" attributeType="String"/>
         <attribute name="cachedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="duration" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="fileSize" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="lastAccessedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="mediaFileId" optional="YES" attributeType="String"/>
         <attribute name="filePath" optional="YES" attributeType="String"/>
+        <attribute name="sampleRate" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="state" optional="YES" attributeType="String"/>
         <attribute name="suffix" optional="YES" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
         <uniquenessConstraints>
             <uniquenessConstraint>
                 <constraint value="cacheKey"/>


### PR DESCRIPTION
This is just a proposal, i am working on a standalone watchOs app based on flo, implementing this cache is necessary on watchOs to save on battery and cellular data. I felt like it could also benefit the other platforms?

PR adds optional (defaults to off for now) transparent pre caching that silently prefetches the next song to disk for instant play/replay on subsequent plays — similar to Spotify's caching behavior. 

Cached files are stored in Library/Caches/StreamCache/ (separate from explicit downloads) with LRU eviction when the user-defined cache limit is reached (default 1 GB).

  Key Changes

  Playback pipeline (AlbumService.swift, PlayerViewModel.swift):
  - getStreamUrl() now resolves in 3 tiers: explicit download → stream cache → remote URL
  - After 10 seconds of confirmed playback, a silent background download is triggered for the next queued song
  - On song skip, in-flight cache downloads are cancelled
  - Live radio and locally-stored tracks are excluded from caching

  Storage (StreamCacheManager.swift, CacheEntity):
  - New StreamCacheManager singleton manages the full cache lifecycle: download, lookup, eviction, cleanup
  - New CacheEntity CoreData entity tracks cached files with LRU metadata (lastAccessedAt)
  - Cache uses Library/Caches/ directory — iOS can purge under storage pressure, reconcile() on app startup handles orphans
  - Cache key includes bitrate setting so quality changes don't serve wrong files

  Settings (PreferencesView.swift):
  - Cache size display, configurable limit (Off / 500 MB / 1 GB / 2 GB / 5 GB), and "Clear streaming cache" button to release storage


<img width="417" height="497" alt="image" src="https://github.com/user-attachments/assets/e8482eff-be92-49d6-8819-d77cdd199870" />
