### PR TITLE
Liked Songs

### DIFF
--- a/flo.xcodeproj/project.pbxproj
+++ b/flo.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		C47876042C2BFFF900184A33 /* SongView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C47876032C2BFFF900184A33 /* SongView.swift */; };
 		C4824D232CE8C41F003EAB52 /* Playable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4824D222CE8C41D003EAB52 /* Playable.swift */; };
 		C4824D272CE908DC003EAB52 /* SongsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4824D262CE908DA003EAB52 /* SongsView.swift */; };
+		0E1A2B3C4D5E6F7A8B9C0D1E /* LikedSongsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2A3B4C5D6E7F8A9B0C1D2E /* LikedSongsView.swift */; };
 		C4875E002C149D9000D9BAEB /* AlbumService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4875DFF2C149D9000D9BAEB /* AlbumService.swift */; };
 		C4875E022C149DDD00D9BAEB /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4875E012C149DDD00D9BAEB /* AuthService.swift */; };
 		C4875E042C149F9A00D9BAEB /* APIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4875E032C149F9A00D9BAEB /* APIManager.swift */; };
@@ -230,6 +231,7 @@
 		C47876032C2BFFF900184A33 /* SongView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongView.swift; sourceTree = "<group>"; };
 		C4824D222CE8C41D003EAB52 /* Playable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Playable.swift; sourceTree = "<group>"; };
 		C4824D262CE908DA003EAB52 /* SongsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongsView.swift; sourceTree = "<group>"; };
+		0E2A3B4C5D6E7F8A9B0C1D2E /* LikedSongsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikedSongsView.swift; sourceTree = "<group>"; };
 		C4875DFF2C149D9000D9BAEB /* AlbumService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumService.swift; sourceTree = "<group>"; };
 		C4875E012C149DDD00D9BAEB /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		C4875E032C149F9A00D9BAEB /* APIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIManager.swift; sourceTree = "<group>"; };
@@ -449,6 +451,7 @@
 				C4A4BF322C14437700363290 /* LibraryView.swift */,
 				C4A4BF362C14442F00363290 /* DownloadsView.swift */,
 				C4A4BF382C14445000363290 /* PreferencesView.swift */,
+				0E2A3B4C5D6E7F8A9B0C1D2E /* LikedSongsView.swift */,
 			);
 			path = Navigation;
 			sourceTree = "<group>";
@@ -701,6 +704,7 @@
 				C47876022C2BF15900184A33 /* AlbumsView.swift in Sources */,
 				50C912A42F648A440087EE61 /* IAPWebAuthView.swift in Sources */,
 				C4824D272CE908DC003EAB52 /* SongsView.swift in Sources */,
+				0E1A2B3C4D5E6F7A8B9C0D1E /* LikedSongsView.swift in Sources */,
 				C456D8FA2F2FF33E002AAB8B /* LRCParser.swift in Sources */,
 				50C912892F5DD9280087EE61 /* AuthMode.swift in Sources */,
 				C4F870CE2CEFCC5E00312F8A /* FloooService.swift in Sources */,

--- a/flo/AlbumViewModel.swift
+++ b/flo/AlbumViewModel.swift
@@ -15,6 +15,7 @@ class AlbumViewModel: ObservableObject {
   @Published var artistAlbums: [Album] = []
   @Published var albums: [Album] = []
   @Published var album: Album = Album()
+  @Published var starredSongs: [Song] = []
   @Published var downloadedAlbums: [Album] = []
 
   @Published var isDownloadingAlbumId: String = ""
@@ -108,6 +109,19 @@ class AlbumViewModel: ObservableObject {
         case .success(let songs):
           self.songs = songs
 
+        case .failure(let error):
+          self.error = error
+        }
+      }
+    }
+  }
+
+  func fetchStarredSongs() {
+    AlbumService.shared.getStarredSongs { result in
+      DispatchQueue.main.async {
+        switch result {
+        case .success(let songs):
+          self.starredSongs = songs
         case .failure(let error):
           self.error = error
         }

--- a/flo/CarPlay/CarPlayNowPlayingManager.swift
+++ b/flo/CarPlay/CarPlayNowPlayingManager.swift
@@ -58,21 +58,23 @@ class CarPlayNowPlayingManager: NSObject {
       self?.playerVM.shuffleCurrentQueue()
     }
 
-    let isLiveRadio = playerVM.isLiveRadio
-    let heartImage = UIImage(
-      systemName: playerVM.isStarred && !isLiveRadio ? "heart.fill" : "heart"
-    )?.withRenderingMode(.alwaysTemplate)
-
-    let heartButton = CPNowPlayingImageButton(image: heartImage ?? UIImage()) { [weak self] _ in
-      guard let self = self, !self.playerVM.isLiveRadio else { return }
-      self.playerVM.toggleStar()
-    }
-
     let repeatButton = CPNowPlayingRepeatButton { [weak self] _ in
       self?.playerVM.setPlaybackMode()
     }
 
-    template.updateNowPlayingButtons([shuffleButton, heartButton, repeatButton])
+    if playerVM.isLiveRadio {
+      template.updateNowPlayingButtons([shuffleButton, repeatButton])
+    } else {
+      let heartImage = UIImage(
+        systemName: playerVM.isStarred ? "heart.fill" : "heart"
+      )?.withRenderingMode(.alwaysTemplate)
+
+      let heartButton = CPNowPlayingImageButton(image: heartImage ?? UIImage()) { [weak self] _ in
+        self?.playerVM.toggleStar()
+      }
+
+      template.updateNowPlayingButtons([shuffleButton, heartButton, repeatButton])
+    }
   }
 }
 

--- a/flo/CarPlay/CarPlayNowPlayingManager.swift
+++ b/flo/CarPlay/CarPlayNowPlayingManager.swift
@@ -39,6 +39,13 @@ class CarPlayNowPlayingManager: NSObject {
         self?.updateButtons(on: nowPlaying)
       }
       .store(in: &cancellables)
+
+    playerVM.$isStarred
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] _ in
+        self?.updateButtons(on: nowPlaying)
+      }
+      .store(in: &cancellables)
   }
 
   func teardown() {
@@ -51,11 +58,21 @@ class CarPlayNowPlayingManager: NSObject {
       self?.playerVM.shuffleCurrentQueue()
     }
 
+    let isLiveRadio = playerVM.isLiveRadio
+    let heartImage = UIImage(
+      systemName: playerVM.isStarred && !isLiveRadio ? "heart.fill" : "heart"
+    )?.withRenderingMode(.alwaysTemplate)
+
+    let heartButton = CPNowPlayingImageButton(image: heartImage ?? UIImage()) { [weak self] _ in
+      guard let self = self, !self.playerVM.isLiveRadio else { return }
+      self.playerVM.toggleStar()
+    }
+
     let repeatButton = CPNowPlayingRepeatButton { [weak self] _ in
       self?.playerVM.setPlaybackMode()
     }
 
-    template.updateNowPlayingButtons([shuffleButton, repeatButton])
+    template.updateNowPlayingButtons([shuffleButton, heartButton, repeatButton])
   }
 }
 

--- a/flo/Navigation/LibraryView.swift
+++ b/flo/Navigation/LibraryView.swift
@@ -78,6 +78,27 @@ struct LibraryView: View {
             Divider()
 
             NavigationLink {
+              LikedSongsView()
+                .environmentObject(viewModel)
+                .environmentObject(playerViewModel)
+            } label: {
+              HStack {
+                Image(systemName: "heart.fill")
+                  .frame(width: 20, height: 10)
+                  .foregroundColor(.accent)
+                Text("Liked Songs")
+                  .customFont(.headline)
+                  .padding(.leading, 8)
+                Spacer()
+                Image(systemName: "chevron.right")
+                  .foregroundColor(.gray)
+                  .font(.caption)
+              }.padding(.horizontal).padding(.vertical, 5)
+            }
+
+            Divider()
+
+            NavigationLink {
               PlaylistView()
                 .environmentObject(viewModel)
                 .environmentObject(playerViewModel)

--- a/flo/Navigation/LikedSongsView.swift
+++ b/flo/Navigation/LikedSongsView.swift
@@ -1,0 +1,72 @@
+//
+//  LikedSongsView.swift
+//  flo
+//
+
+import NukeUI
+import SwiftUI
+
+struct LikedSongsView: View {
+  @EnvironmentObject private var viewModel: AlbumViewModel
+  @EnvironmentObject private var playerViewModel: PlayerViewModel
+
+  var body: some View {
+    ScrollView {
+      LazyVStack {
+        ForEach(Array(viewModel.starredSongs.enumerated()), id: \.element.id) { idx, song in
+          VStack {
+            HStack {
+              LazyImage(url: URL(string: viewModel.getAlbumCoverArt(id: song.albumId))) { state in
+                if let image = state.image {
+                  image
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 60, height: 60)
+                    .clipShape(
+                      RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    )
+                } else {
+                  Color("PlayerColor").frame(width: 60, height: 60)
+                    .cornerRadius(5)
+                }
+              }
+
+              VStack(alignment: .leading) {
+                Text(song.title)
+                  .customFont(.headline)
+                  .multilineTextAlignment(.leading)
+                  .lineLimit(2)
+                  .padding(.bottom, 3)
+
+                Text(song.artist)
+                  .customFont(.subheadline)
+                  .foregroundColor(.gray)
+                  .lineLimit(2)
+                  .multilineTextAlignment(.leading)
+              }
+              .padding(.horizontal, 10)
+
+              Spacer()
+            }
+            .padding(.horizontal)
+            .background(Color(UIColor.systemBackground))
+
+            Divider()
+          }
+          .onTapGesture {
+            let liked = SongCollection(
+              id: "starred-songs", name: "Liked Songs", songs: viewModel.starredSongs)
+            playerViewModel.playBySong(idx: idx, item: liked, isFromLocal: false)
+          }
+          .frame(maxWidth: .infinity, alignment: .leading)
+        }
+      }
+      .padding(.top, 10)
+      .padding(.bottom, 100)
+      .navigationTitle("Liked Songs")
+    }
+    .onAppear {
+      viewModel.fetchStarredSongs()
+    }
+  }
+}

--- a/flo/Navigation/LikedSongsView.swift
+++ b/flo/Navigation/LikedSongsView.swift
@@ -68,5 +68,8 @@ struct LikedSongsView: View {
     .onAppear {
       viewModel.fetchStarredSongs()
     }
+    .onChange(of: playerViewModel.isStarred) { _ in
+      viewModel.fetchStarredSongs()
+    }
   }
 }

--- a/flo/PlayerView.swift
+++ b/flo/PlayerView.swift
@@ -404,7 +404,7 @@ struct PlayerView: View {
           .foregroundColor(isLyricsDisabled ? .white.opacity(0.4) : .white)
       }
       .disabled(isLyricsDisabled)
-      .frame(width: 56, alignment: .leading)
+      .frame(maxWidth: .infinity)
 
       Button {
         viewModel.toggleStar()
@@ -415,10 +415,11 @@ struct PlayerView: View {
       }
       .disabled(viewModel.isLiveRadio)
       .opacity(viewModel.isLiveRadio ? 0.4 : 1)
+      .frame(maxWidth: .infinity)
 
       AirPlayRoutePicker(tintColor: UIColor.white, activeTintColor: UIColor.white)
-        .frame(width: 36, height: 36, alignment: .center)
-        .frame(maxWidth: .infinity, alignment: .center)
+        .frame(width: 36, height: 36)
+        .frame(maxWidth: .infinity)
         .overlay(alignment: .bottom) {
           if let outputName = viewModel.externalOutputName {
             Text(outputName)
@@ -464,7 +465,7 @@ struct PlayerView: View {
       }
       .disabled(isQueueDisabled)
       .opacity(isQueueDisabled ? 0.4 : 1)
-      .frame(width: 56, alignment: .trailing)
+      .frame(maxWidth: .infinity)
     }
   }
 

--- a/flo/PlayerView.swift
+++ b/flo/PlayerView.swift
@@ -406,6 +406,16 @@ struct PlayerView: View {
       .disabled(isLyricsDisabled)
       .frame(width: 56, alignment: .leading)
 
+      Button {
+        viewModel.toggleStar()
+      } label: {
+        Image(systemName: viewModel.isStarred ? "heart.fill" : "heart")
+          .font(.title2)
+          .foregroundColor(viewModel.isStarred ? .red : .white)
+      }
+      .disabled(viewModel.isLiveRadio)
+      .opacity(viewModel.isLiveRadio ? 0.4 : 1)
+
       AirPlayRoutePicker(tintColor: UIColor.white, activeTintColor: UIColor.white)
         .frame(width: 36, height: 36, alignment: .center)
         .frame(maxWidth: .infinity, alignment: .center)

--- a/flo/PlayerViewModel.swift
+++ b/flo/PlayerViewModel.swift
@@ -40,6 +40,7 @@ class PlayerViewModel: ObservableObject {
   @Published var totalTimeString: String = "00:00"
   @Published var shouldHidePlayer: Bool = false
   @Published var externalOutputName: String?
+  @Published var isStarred: Bool = false
 
   // FIXME: this make confusion with `isDownloaded` and/or `isPlayingFromLocal`
   @Published var _playFromLocal: Bool = false
@@ -200,6 +201,7 @@ class PlayerViewModel: ObservableObject {
     try? AVAudioSession.sharedInstance().setActive(true)
 
     self.resetLyrics()
+    self.checkStarredStatus()
 
     if let timeObserverToken = timeObserverToken {
       player?.removeTimeObserver(timeObserverToken)
@@ -787,6 +789,35 @@ class PlayerViewModel: ObservableObject {
     }
 
     return nil
+  }
+
+  private func checkStarredStatus() {
+    self.isStarred = false
+    if let songId = self.nowPlaying.id, !songId.isEmpty {
+      AlbumService.shared.isStarred(songId: songId) { [weak self] starred in
+        DispatchQueue.main.async {
+          guard self?.nowPlaying.id == songId else { return }
+          self?.isStarred = starred
+        }
+      }
+    }
+  }
+
+  func toggleStar() {
+    guard let songId = self.nowPlaying.id, !songId.isEmpty else { return }
+
+    let shouldStar = !self.isStarred
+    self.isStarred = shouldStar
+
+    let action = shouldStar ? AlbumService.shared.starSong : AlbumService.shared.unstarSong
+    action(songId) { [weak self] success in
+      if !success {
+        DispatchQueue.main.async {
+          guard self?.nowPlaying.id == songId else { return }
+          self?.isStarred = !shouldStar
+        }
+      }
+    }
   }
 
   deinit {

--- a/flo/Resources/Localizable.xcstrings
+++ b/flo/Resources/Localizable.xcstrings
@@ -790,6 +790,9 @@
         }
       }
     },
+    "Liked Songs" : {
+
+    },
     "Link copied to clipboard! (%@)" : {
       "localizations" : {
         "en" : {

--- a/flo/Shared/Models/Playable.swift
+++ b/flo/Shared/Models/Playable.swift
@@ -11,3 +11,10 @@ protocol Playable {
   var songs: [Song] { get set }
   var artist: String { get }
 }
+
+struct SongCollection: Playable {
+  let id: String
+  let name: String
+  var songs: [Song]
+  let artist: String = ""
+}

--- a/flo/Shared/Models/Song.swift
+++ b/flo/Shared/Models/Song.swift
@@ -22,6 +22,7 @@ struct Song: Codable, Identifiable, Hashable {
 
   var mediaFileId: String = ""
   var fileUrl: String = ""
+  var starred: Bool = false
 
   enum DecodeKeys: String, CodingKey {
     case id
@@ -37,6 +38,7 @@ struct Song: Codable, Identifiable, Hashable {
     case suffix
     case duration
     case mediaFileId
+    case starred
   }
 
   enum EncodeKeys: String, CodingKey {
@@ -52,6 +54,7 @@ struct Song: Codable, Identifiable, Hashable {
     case suffix
     case duration
     case mediaFileId
+    case starred
   }
 
   init(from decoder: any Decoder) throws {
@@ -73,6 +76,7 @@ struct Song: Codable, Identifiable, Hashable {
     self.suffix = try container.decode(String.self, forKey: .suffix)
     self.duration = try container.decode(Double.self, forKey: .duration)
     self.mediaFileId = try container.decodeIfPresent(String.self, forKey: .mediaFileId) ?? ""
+    self.starred = try container.decodeIfPresent(Bool.self, forKey: .starred) ?? false
   }
 
   func encode(to encoder: any Encoder) throws {
@@ -90,6 +94,7 @@ struct Song: Codable, Identifiable, Hashable {
     try container.encode(suffix, forKey: .suffix)
     try container.encode(duration, forKey: .duration)
     try container.encode(mediaFileId, forKey: .mediaFileId)
+    try container.encode(starred, forKey: .starred)
   }
 
   init(

--- a/flo/Shared/Models/Subsonic.swift
+++ b/flo/Shared/Models/Subsonic.swift
@@ -75,3 +75,45 @@ extension SubsonicResponse {
 }
 
 typealias BasicSubsonicResponse = SubsonicResponse<BasicResponse>
+
+struct Starred2Response: Codable {
+  struct SubsonicResponseBody: Codable {
+    struct Starred2: Codable {
+      let song: [SubsonicSong]?
+    }
+
+    let starred2: Starred2?
+  }
+
+  let subsonicResponse: SubsonicResponseBody
+
+  enum CodingKeys: String, CodingKey {
+    case subsonicResponse = "subsonic-response"
+  }
+
+  var songs: [Song] {
+    return (subsonicResponse.starred2?.song ?? []).map { $0.toSong() }
+  }
+}
+
+struct SubsonicSong: Codable {
+  let id: String
+  let title: String
+  let artist: String?
+  let albumId: String?
+  let album: String?
+  let track: Int?
+  let discNumber: Int?
+  let bitRate: Int?
+  let samplingRate: Int?
+  let suffix: String?
+  let duration: Int?
+
+  func toSong() -> Song {
+    return Song(
+      id: id, title: title, albumId: albumId ?? "", albumName: album ?? "",
+      artist: artist ?? "", trackNumber: track ?? 0, discNumber: discNumber ?? 0,
+      bitRate: bitRate ?? 0, sampleRate: samplingRate ?? 0, suffix: suffix ?? "",
+      duration: Double(duration ?? 0), mediaFileId: id)
+  }
+}

--- a/flo/Shared/Services/AlbumService.swift
+++ b/flo/Shared/Services/AlbumService.swift
@@ -37,6 +37,58 @@ class AlbumService {
     return buildRemoteStreamUrl(id: id)
   }
 
+  func isStarred(songId: String, completion: @escaping (Bool) -> Void) {
+    let params: [String: Any] = [
+      "_start": 0, "_end": 1, "id": songId,
+    ]
+
+    APIManager.shared.NDEndpointRequest(endpoint: API.NDEndpoint.getSong, parameters: params) {
+      (response: DataResponse<[Song], AFError>) in
+      switch response.result {
+      case .success(let songs):
+        completion(songs.first?.starred ?? false)
+      case .failure:
+        completion(false)
+      }
+    }
+  }
+
+  func starSong(id: String, completion: @escaping (Bool) -> Void) {
+    let url =
+      "\(UserDefaultsManager.serverBaseURL)\(API.SubsonicEndpoint.star)\(AuthService.shared.getCreds(key: "subsonicToken"))&id=\(id)"
+
+    APIManager.shared.session.request(url)
+      .validate(statusCode: 200..<300)
+      .response { response in
+        completion(response.error == nil)
+      }
+  }
+
+  func unstarSong(id: String, completion: @escaping (Bool) -> Void) {
+    let url =
+      "\(UserDefaultsManager.serverBaseURL)\(API.SubsonicEndpoint.unstar)\(AuthService.shared.getCreds(key: "subsonicToken"))&id=\(id)"
+
+    APIManager.shared.session.request(url)
+      .validate(statusCode: 200..<300)
+      .response { response in
+        completion(response.error == nil)
+      }
+  }
+
+  func getStarredSongs(completion: @escaping (Result<[Song], Error>) -> Void) {
+    APIManager.shared.SubsonicEndpointRequest(
+      endpoint: API.SubsonicEndpoint.getStarred2, parameters: nil
+    ) {
+      (response: DataResponse<Starred2Response, AFError>) in
+      switch response.result {
+      case .success(let starred):
+        completion(.success(starred.songs))
+      case .failure(let error):
+        completion(.failure(error))
+      }
+    }
+  }
+
   func getSongFromAlbum(id: String, completion: @escaping (Result<[Song], Error>) -> Void) {
     // FIXME: get all songs for now
     let params: [String: Any] = [

--- a/flo/Shared/Services/FloooService.swift
+++ b/flo/Shared/Services/FloooService.swift
@@ -75,8 +75,8 @@ class FloooService {
       switch result {
       case .success(let status):
         listenBrainzStatus = status
-      case .failure(let err):
-        error = err
+      case .failure:
+        listenBrainzStatus = false
       }
 
       group.leave()
@@ -88,27 +88,19 @@ class FloooService {
       switch result {
       case .success(let status):
         lastFMStatus = status
-      case .failure(let err):
-        error = err
+      case .failure:
+        lastFMStatus = false
       }
 
       group.leave()
     }
 
     group.notify(queue: .main) {
-      if let error = error {
-        completion(.failure(error))
-
-        return
-      }
-
-      guard let listenBrainz = listenBrainzStatus, let lastFm = lastFMStatus else {
-        completion(.failure(NSError(domain: "", code: -1)))
-
-        return
-      }
-
-      completion(.success(AccountLinkStatus(listenBrainz: listenBrainz, lastFM: lastFm)))
+      completion(
+        .success(
+          AccountLinkStatus(
+            listenBrainz: listenBrainzStatus ?? false,
+            lastFM: lastFMStatus ?? false)))
     }
   }
 

--- a/flo/Shared/Utils/Constants.swift
+++ b/flo/Shared/Utils/Constants.swift
@@ -32,6 +32,9 @@ struct API {
     static let radios = "/rest/getInternetRadioStations"
     static let similarSongs = "/rest/getSimilarSongs2"
     static let topSongs = "/rest/getTopSongs"
+    static let star = "/rest/star"
+    static let unstar = "/rest/unstar"
+    static let getStarred2 = "/rest/getStarred2"
   }
 }
 


### PR DESCRIPTION
This adds the ability to like/unlike songs across iOS and CarPlay with a dedicated Liked Songs view in the Library similar to how Spotify lets the user like songs. 

  - Add song star/unstar support via Subsonic star/unstar API
  - Heart button in the iOS now playing bar to like/unlike the current track
  - Heart button in CarPlay now playing (not radio)
  - New "Liked Songs" entry in the Library tab that shows all starred songs from the server via getStarred2
  - Tapping a song in Liked Songs queues all starred songs as a playlist

<img width="439" height="359" alt="image" src="https://github.com/user-attachments/assets/d26c5051-fbfc-4362-a11d-9623f5c46ae8" />
<img width="728" height="437" alt="image" src="https://github.com/user-attachments/assets/79fded66-a8a0-45e8-b373-14ad6bda339f" />
<img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/d32d4901-5fd9-4375-87c6-6035e6135bf2" />

