### PR TITLE
Add cached songs to CarPlay Downloads tab

### DIFF
--- a/flo/CarPlay/CarPlayCoordinator.swift
+++ b/flo/CarPlay/CarPlayCoordinator.swift
@@ -593,13 +593,31 @@ class CarPlayCoordinator {
     AlbumService.shared.getDownloadedAlbum { [weak self] result in
       DispatchQueue.main.async {
         guard let self = self else { return }
+
+        let cachedSongs = StreamCacheManager.shared.getCachedSongs()
+        var sections: [CPListSection] = []
+
+        // Cached songs section
+        if !cachedSongs.isEmpty {
+          let cachedItem = CPListItem(
+            text: String(localized: "Cached"),
+            detailText: String(localized: "\(cachedSongs.count) songs"),
+            image: UIImage(systemName: "music.note.list")?.withRenderingMode(.alwaysTemplate)
+          )
+          cachedItem.handler = { [weak self] _, completion in
+            self?.showCachedSongs(songs: cachedSongs)
+            completion()
+          }
+          sections.append(CPListSection(items: [cachedItem]))
+        }
+
         switch result {
         case .success(let albums):
           let filtered = albums.filter { album in
             !AlbumService.shared.getSongsByAlbumId(albumId: album.id).isEmpty
           }
 
-          if filtered.isEmpty {
+          if filtered.isEmpty && cachedSongs.isEmpty {
             template.updateSections([
               CPListSection(items: [
                 CPListItem(text: String(localized: "No downloads"), detailText: String(localized: "Download music from the app"))
@@ -628,18 +646,81 @@ class CarPlayCoordinator {
             }
             return item
           }
-          template.updateSections([CPListSection(items: items)])
+          if !items.isEmpty {
+            sections.append(CPListSection(
+              items: items,
+              header: String(localized: "Albums"),
+              sectionIndexTitle: nil
+            ))
+          }
+          template.updateSections(sections)
 
         case .failure:
-          template.updateSections([
-            CPListSection(items: [
-              CPListItem(text: String(localized: "No downloads available"), detailText: nil)
+          if cachedSongs.isEmpty {
+            template.updateSections([
+              CPListSection(items: [
+                CPListItem(text: String(localized: "No downloads available"), detailText: nil)
+              ])
             ])
-          ])
+          } else {
+            template.updateSections(sections)
+          }
         }
       }
     }
 
     return template
+  }
+
+  // MARK: - Cached Songs
+
+  private func showCachedSongs(songs: [Song]) {
+    let playAllItem = CPListItem(
+      text: String(localized: "Play All"),
+      detailText: String(localized: "\(songs.count) songs"),
+      image: UIImage(systemName: "play.fill")
+    )
+    playAllItem.handler = { [weak self] _, completion in
+      let collection = SongCollection(id: "cached-songs", name: "Cached", songs: songs)
+      self?.playerVM.playItem(item: collection, isFromLocal: true)
+      self?.showNowPlaying()
+      completion()
+    }
+
+    let shuffleItem = CPListItem(
+      text: String(localized: "Shuffle"),
+      detailText: nil,
+      image: UIImage(systemName: "shuffle")
+    )
+    shuffleItem.handler = { [weak self] _, completion in
+      let collection = SongCollection(id: "cached-songs", name: "Cached", songs: songs)
+      self?.playerVM.shuffleItem(item: collection, isFromLocal: true)
+      self?.showNowPlaying()
+      completion()
+    }
+
+    let actionSection = CPListSection(items: [playAllItem, shuffleItem])
+
+    let trackItems = songs.enumerated().map { (idx, song) -> CPListItem in
+      let item = CPListItem(
+        text: song.title,
+        detailText: song.artist
+      )
+      item.handler = { [weak self] _, completion in
+        let collection = SongCollection(id: "cached-songs", name: "Cached", songs: songs)
+        self?.playerVM.playBySong(idx: idx, item: collection, isFromLocal: true)
+        self?.showNowPlaying()
+        completion()
+      }
+      return item
+    }
+    let trackSection = CPListSection(
+      items: trackItems,
+      header: String(localized: "Tracks"),
+      sectionIndexTitle: nil
+    )
+
+    let template = CPListTemplate(title: String(localized: "Cached"), sections: [actionSection, trackSection])
+    interfaceController.pushTemplate(template, animated: true, completion: nil)
   }
 }


### PR DESCRIPTION
Follow-up to #115 — adds stream-cached songs to the CarPlay Downloads tab.

Cached songs appear as a browsable entry at the top of the Downloads tab showing the song count. Tapping it presents Play All, Shuffle, and individual track selection, all playing from local cache. Only shows when cached songs exist. Works fully offline since playback resolves to on-disk files with no network dependency.

<img width="800" height="480" alt="image" src="https://github.com/user-attachments/assets/2ab39921-68d1-42bc-a33a-270fdeb7a5c8" />

<img width="800" height="480" alt="image" src="https://github.com/user-attachments/assets/7acb2656-6774-49c9-b163-a2831d2f2aab" />
