### PR TITLE
Fixed non-square album art pushing adjacent albums out of alignment

### DIFF
--- a/flo/AlbumsView.swift
+++ b/flo/AlbumsView.swift
@@ -22,54 +22,24 @@ struct AlbumsView: View {
             contentsOfFile: viewModel.getAlbumCoverArt(
               id: album.id, artistName: album.artist, albumName: album.name, albumCover: album.albumCover))
           {
-            Image(uiImage: image)
-              .resizable()
-              .aspectRatio(contentMode: .fill)
-              .frame(maxWidth: .infinity, maxHeight: 300)
-              .clipShape(
-                RoundedRectangle(cornerRadius: 5, style: .continuous)
-              )
+            albumArtwork(Image(uiImage: image))
           } else {
             if let image = UIImage(named: "placeholder") {
-              Image(uiImage: image)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(maxWidth: .infinity, maxHeight: 300)
-                .clipShape(
-                  RoundedRectangle(cornerRadius: 5, style: .continuous)
-                )
+              albumArtwork(Image(uiImage: image))
             }
           }
         } else {
           if let image = UIImage(
             contentsOfFile: viewModel.getAlbumCoverArt(id: album.id, albumCover: album.albumCover))
           {
-            Image(uiImage: image)
-              .resizable()
-              .aspectRatio(contentMode: .fill)
-              .frame(maxWidth: .infinity, maxHeight: 300)
-              .clipShape(
-                RoundedRectangle(cornerRadius: 5, style: .continuous)
-              )
+            albumArtwork(Image(uiImage: image))
           } else {
             LazyImage(url: URL(string: viewModel.getAlbumCoverArt(id: album.id, albumCover: album.albumCover))) { state in
               if let image = state.image {
-                image
-                  .resizable()
-                  .aspectRatio(contentMode: .fill)
-                  .frame(maxWidth: .infinity, maxHeight: 300)
-                  .clipShape(
-                    RoundedRectangle(cornerRadius: 5, style: .continuous)
-                  )
+                albumArtwork(image)
               } else {
                 if let image = UIImage(named: "placeholder") {
-                  Image(uiImage: image)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(maxWidth: .infinity, maxHeight: 300)
-                    .clipShape(
-                      RoundedRectangle(cornerRadius: 5, style: .continuous)
-                    )
+                  albumArtwork(Image(uiImage: image))
                 }
               }
             }
@@ -95,6 +65,19 @@ struct AlbumsView: View {
           .frame(maxWidth: .infinity, alignment: .leading)
       }.padding()
     }
+  }
+
+  private func albumArtwork(_ image: Image) -> some View {
+    GeometryReader { proxy in
+      image
+        .resizable()
+        .scaledToFill()
+        .frame(width: proxy.size.width, height: proxy.size.width)
+        .clipShape(
+          RoundedRectangle(cornerRadius: 5, style: .continuous)
+        )
+    }
+    .aspectRatio(1, contentMode: .fit)
   }
 }
 


### PR DESCRIPTION
Fixed an issue noted in #108 that affected non-standard album covers to push adjacent albums out of alignment.
Cassette and other album art is now scaled to fill a square.
Before:
<img width="170" alt="Before" src="https://github.com/user-attachments/assets/a5efc35e-c2ab-4c2d-98b4-61fdac38e8fb" />
After:
<img width="170" alt="After" src="https://github.com/user-attachments/assets/83153d60-d0d4-4993-aa3d-283ea39e8f73" />
