### PR TITLE
feat: display playlist cover art if available

### DIFF
--- a/flo/AlbumViewModel.swift
+++ b/flo/AlbumViewModel.swift
@@ -217,6 +217,11 @@ class AlbumViewModel: ObservableObject {
     return AlbumService.shared.getAlbumCover(
       artistName: artistName, albumName: albumName, albumId: id, albumCover: albumCover)
   }
+    
+  func getPlaylistCoverArt(id: String, coverArtId: String? = nil) -> String {
+      let artId = coverArtId ?? id
+      return AlbumService.shared.getPlaylistCover(playlistId: artId)
+  }
 
   func shareAlbum(description: String, completion: @escaping (String) -> Void) {
     AlbumService.shared.share(albumId: self.album.id, description: description, downloadable: false)

--- a/flo/PlaylistDetailView.swift
+++ b/flo/PlaylistDetailView.swift
@@ -7,6 +7,39 @@
 
 import SwiftUI
 
+struct PlaylistCoverImageView: View {
+  let pathOrUrlString: String
+
+  var body: some View {
+    if pathOrUrlString.hasPrefix("http://") || pathOrUrlString.hasPrefix("https://") {
+      AsyncImage(url: URL(string: pathOrUrlString)) { phase in
+        switch phase {
+        case .success(let image):
+          image
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+        case .failure, .empty:
+          placeholderImage
+        @unknown default:
+          placeholderImage
+        }
+      }
+    } else if let uiImage = UIImage(contentsOfFile: pathOrUrlString) {
+      Image(uiImage: uiImage)
+        .resizable()
+        .aspectRatio(contentMode: .fit)
+    } else {
+      placeholderImage
+    }
+  }
+
+  private var placeholderImage: some View {
+    Image(uiImage: UIImage(named: "placeholder") ?? UIImage())
+      .resizable()
+      .aspectRatio(contentMode: .fit)
+  }
+}
+
 struct PlaylistDetailView: View {
   @EnvironmentObject private var viewModel: AlbumViewModel
   @EnvironmentObject private var playerViewModel: PlayerViewModel
@@ -18,17 +51,18 @@ struct PlaylistDetailView: View {
   var body: some View {
     ScrollView {
       VStack {
-        if let image = UIImage(named: "placeholder") {
-          Image(uiImage: image)
-            .resizable()
-            .aspectRatio(contentMode: .fit)
-            .frame(width: 300, height: 300)
-            .clipShape(
-              RoundedRectangle(cornerRadius: 10, style: .continuous)
+          PlaylistCoverImageView(
+            pathOrUrlString: viewModel.getPlaylistCoverArt(
+              id: viewModel.playlist.id,
+              coverArtId: viewModel.playlist.coverArtId
             )
-            .shadow(radius: 5)
-            .padding(.top, 10)
-        }
+          )
+          .frame(width: 300, height: 300)
+          .clipShape(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+          )
+          .shadow(radius: 5)
+          .padding(.top, 10)
 
         Text(viewModel.playlist.name)
           .customFont(.title)

--- a/flo/Shared/Models/Playlist.swift
+++ b/flo/Shared/Models/Playlist.swift
@@ -14,6 +14,7 @@ struct Playlist: Codable, Identifiable, Hashable, Playable {
   let isPublic: Bool
   let ownerName: String
   let artist: String
+  let coverArtId: String?
   var songs: [Song] = []
 
   enum CodingKeys: String, CodingKey {
@@ -22,18 +23,25 @@ struct Playlist: Codable, Identifiable, Hashable, Playable {
     case comment
     case isPublic = "public"
     case ownerName
+    case coverArtId
     case songs
   }
 
   init(
-    id: String = "", name: String = "", comment: String = "", isPublic: Bool = false,
-    ownerName: String = "", songs: [Song] = []
+    id: String = "",
+    name: String = "",
+    comment: String = "",
+    isPublic: Bool = false,
+    ownerName: String = "",
+    coverArtId: String? = nil,
+    songs: [Song] = []
   ) {
     self.id = id
     self.name = name
     self.comment = comment
     self.isPublic = isPublic
     self.ownerName = ownerName
+    self.coverArtId = coverArtId
     self.songs = songs
     self.artist = ownerName
   }
@@ -46,6 +54,7 @@ struct Playlist: Codable, Identifiable, Hashable, Playable {
     self.comment = try container.decode(String.self, forKey: .comment)
     self.isPublic = try container.decode(Bool.self, forKey: .isPublic)
     self.ownerName = try container.decode(String.self, forKey: .ownerName)
+    self.coverArtId = try container.decodeIfPresent(String.self, forKey: .coverArtId)
     self.songs = try container.decodeIfPresent([Song].self, forKey: .songs) ?? []
     self.artist = try container.decode(String.self, forKey: .ownerName)
   }

--- a/flo/Shared/Services/AlbumService.swift
+++ b/flo/Shared/Services/AlbumService.swift
@@ -302,6 +302,19 @@ class AlbumService {
         "\(UserDefaultsManager.serverBaseURL)\(API.SubsonicEndpoint.coverArt)\(AuthService.shared.getCreds(key: "subsonicToken"))&id=al-\(albumId)&size=300"
     }
   }
+    
+    func getPlaylistCover(playlistId: String) -> String {
+      let target = "Media/Various Artists/\(playlistId)/cover.png"
+      
+      if LocalFileManager.shared.fileExists(fileName: target) {
+        return LocalFileManager.shared.fileURL(for: target)?.path ?? ""
+      } else if let cached = CoverArtCacheManager.shared.cachedFilePath(albumId: playlistId) {
+        return cached
+      } else {
+        let artId = playlistId.hasPrefix("pl-") ? playlistId : "pl-\(playlistId)"
+        return "\(UserDefaultsManager.serverBaseURL)\(API.SubsonicEndpoint.coverArt)\(AuthService.shared.getCreds(key: "subsonicToken"))&id=\(artId)&size=300"
+      }
+    }
 
   func downloadAlbumCover(
     artistName: String, albumId: String, albumName: String,


### PR DESCRIPTION
## Description
This PR implements functionality to fetch and display playlist cover art directly from the server if it supports it. Previously, playlists would display a placeholder image by default; now, the UI displays the custom playlist cover art.

## Changes
- Updated PlaylistDetailView, AlbumService, AlbumViewModel, and Playlist logic to check for server-provided cover art.
- If no cover art is returned by the server, the placeholder image is displayed.

## Screenshots

| Before | After |
| :---: | :---: |
| iPhone XS Device | iPhone 17 Simulator |
| <img width="320" height="640" alt="IMG_3299" src="https://github.com/user-attachments/assets/fd7982fb-0238-47f0-877d-7381c867bd80" /> | <img width="320" height="640" alt="Simulator Screenshot - iPhone 17 - 2026-07-30 at 18 04 15" src="https://github.com/user-attachments/assets/72ae1841-9312-415d-8883-f6899282b001" /> |