### PR TITLE
Basic deeplink support

### DIFF
--- a/flo/Info.plist
+++ b/flo/Info.plist
@@ -40,5 +40,16 @@
 	<array>
 		<string>audio</string>
 	</array>
+  <key>CFBundleURLTypes</key>
+  <array>
+    <dict>
+    <key>CFBundleURLName</key>
+    <string>app.flo</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>flo</string>
+    </array>
+    </dict>
+  </array>
 </dict>
 </plist>

--- a/flo/SceneDelegate.swift
+++ b/flo/SceneDelegate.swift
@@ -42,4 +42,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   func sceneWillEnterForeground(_: UIScene) {}
 
   func sceneDidEnterBackground(_: UIScene) {}
+
+  func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    guard let _ = URLContexts.first?.url else { return }
+    // URL scheme registered for app launch; routing not yet implemented
+  }
 }


### PR DESCRIPTION
I figured I'd open this as a PR rather than an issue/feature request, but if it's crap feel free to reject it. This is my first attempt at modifying a Swift project so I may be missing some considerations.

The TL;DR is that this adds basic deeplink support so that the app can be launched by URL scheme (e.g. `flo://`) through things like Widget-based launchers, rather than having to use Shortcuts as an intermediary.

The change should be a noop if it doesn't work - no existing functionality is modified. I don't have a great way to test this locally though :disappointed: 

Thanks for the consideration, and apologies in advance if this is junk :sweat_smile: 