### PR TITLE
Adjust bottom padding for FloatingPlayerView

### DIFF
--- a/flo/ContentView.swift
+++ b/flo/ContentView.swift
@@ -7,6 +7,7 @@
 
 import PulseUI
 import SwiftUI
+import Combine
 
 struct ContentView: View {
   @AppStorage(UserDefaultsKeys.enableDebug) private var enableDebug = false
@@ -309,7 +310,7 @@ struct ContentView: View {
                 #if targetEnvironment(macCatalyst)
                   10
                 #else
-                  geometry.safeAreaInsets.bottom + 20
+                  keyboardHeight > 0 ? -keyboardHeight + geometry.safeAreaInsets.bottom + 8: geometry.safeAreaInsets.bottom + 20
                 #endif
               }()
 
@@ -352,6 +353,17 @@ struct ContentView: View {
     }
     .onAppear {
       PlaybackCoordinator.shared.attach(playerViewModel: playerViewModel)
+    }
+ .onReceive(NotificationCenter.default.publisher(for:
+    UIResponder.keyboardWillShowNotification)) { notification in
+        if let userInfo = notification.userInfo,
+           let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
+            keyboardHeight = keyboardFrame.height
+        }
+    }
+        .onReceive(NotificationCenter.default.publisher(for:
+    UIResponder.keyboardWillHideNotification)) { _ in
+            keyboardHeight = 0
     }
   }
 }

--- a/flo/ContentView.swift
+++ b/flo/ContentView.swift
@@ -310,7 +310,7 @@ struct ContentView: View {
                 #if targetEnvironment(macCatalyst)
                   10
                 #else
-                  isPad ? 0 : (40 + bottomPadding)
+                  geometry.safeAreaInsets.bottom + 20
                 #endif
               }()
 

--- a/flo/ContentView.swift
+++ b/flo/ContentView.swift
@@ -288,7 +288,7 @@ struct ContentView: View {
           PlayerView(isExpanded: $isPlayerExpanded, viewModel: playerViewModel)
             .ignoresSafeArea()
             .offset(y: isPlayerExpanded ? 0 : offScreenY)
-            .animation(.spring(duration: 0.2), value: isPlayerExpanded)
+            .animation(.spring(response: 0.4, dampingFraction: 0.7), value: isPlayerExpanded)
         }
 
         if !isPadSidebar {

--- a/flo/ContentView.swift
+++ b/flo/ContentView.swift
@@ -296,9 +296,8 @@ struct ContentView: View {
             Spacer()
 
             if playerViewModel.hasNowPlaying() && !playerViewModel.shouldHidePlayer {
-              let isSmallScreen = UIScreen.main.bounds.width <= 390
+              if playerViewModel.hasNowPlaying() && !playerViewModel.shouldHidePlayer {
               let isPad = UIDevice.current.userInterfaceIdiom == .pad
-              let bottomPadding: CGFloat = isSmallScreen ? 32 : 0
               let playerWidth: CGFloat? =
                 isPad
                 ? 720

--- a/flo/PlayerView.swift
+++ b/flo/PlayerView.swift
@@ -195,6 +195,9 @@ struct PlayerView: View {
           }
         }
         .offset(y: offset.height)
+        .onChange(of: isExpanded) { expanded in
+            if expanded {offset = .zero}
+        }
         .gesture(
           DragGesture()
             .onChanged { gesture in
@@ -206,10 +209,13 @@ struct PlayerView: View {
               }
             }
             .onEnded { _ in
-              if offset.height > size.height / 3 {
+              if offset.height > size.height / 5 {
                 isExpanded = false
+              } else {
+                  withAnimation(.spring(response: 0.3, dampingFraction: 0.7)){
+                      offset = .zero
+                  }
               }
-              offset = .zero
               isDragging = false
             }
         )

--- a/flo/PlayerView.swift
+++ b/flo/PlayerView.swift
@@ -41,9 +41,6 @@ struct PlayerView: View {
           ZStack(alignment: .topLeading) {
             Color(.systemBackground)
               .ignoresSafeArea()
-              .clipShape(
-                RoundedRectangle(cornerRadius: 15, style: .continuous)
-              )
             VStack(alignment: .leading) {
               HStack {
                 Spacer()
@@ -484,6 +481,7 @@ struct PlayerView: View {
 
   @ViewBuilder
   private func playerBackground() -> some View {
+    GeometryReader { proxy in
     ZStack {
       if UserDefaultsManager.playerBackground == PlayerBackground.translucent {
         if let image = UIImage(contentsOfFile: viewModel.getAlbumCoverArt()) {
@@ -507,7 +505,14 @@ struct PlayerView: View {
         Rectangle().fill(Color("PlayerColor"))
       }
     }
+    .clipShape(RoundedRectangle(cornerRadius: 37, style: .continuous))
+    .frame(
+                width: proxy.size.width,
+                height: proxy.size.height + 50,
+                alignment: .top
+            )
     .environment(\.colorScheme, .dark)
+                   }
     .ignoresSafeArea()
   }
 

--- a/flo/PlayerView.swift
+++ b/flo/PlayerView.swift
@@ -203,7 +203,7 @@ struct PlayerView: View {
               }
             }
             .onEnded { _ in
-              if offset.height > size.height / 5 {
+              if offset.height > size.height / 6 {
                 isExpanded = false
               } else {
                   withAnimation(.spring(response: 0.3, dampingFraction: 0.7)){

--- a/flo/PlayerView.swift
+++ b/flo/PlayerView.swift
@@ -48,11 +48,8 @@ struct PlayerView: View {
               HStack {
                 Spacer()
 
-                Rectangle()
-                  .foregroundColor(Color.gray.opacity(0.3))
-                  .frame(width: 50, height: 5)
-                  .cornerRadius(30)
-                  .padding(.top)
+                DragHandle(color: .gray.opacity(0.3))
+                      .padding(.top)
 
                 Spacer()
               }
@@ -240,11 +237,8 @@ struct PlayerView: View {
     bottomSafeInset: CGFloat
   ) -> some View {
     VStack {
-      Rectangle()
-        .foregroundColor(Color.gray.opacity(0.8))
-        .frame(width: 50, height: 5)
-        .cornerRadius(30)
-        .padding(.top, topSafeInset + 8)
+      DragHandle(color: .gray.opacity(0.8))
+            .padding(.top, topSafeInset + 8)
 
       Spacer()
       let coverArtUrl = viewModel.getAlbumCoverArt()
@@ -532,6 +526,17 @@ struct PlayerView: View {
     }
     .frame(height: 20)
   }
+}
+
+struct DragHandle: View {
+    let color: Color
+    var body: some View {
+        RoundedRectangle(cornerRadius:2.5)
+            .fill(color)
+            .frame(width: 50, height: 5)
+            .frame(width: 80, height: 44)
+            .contentShape(Rectangle())
+    }
 }
 
 struct PlayerView_previews: PreviewProvider {


### PR DESCRIPTION
Forgive me, this is my first pull request ever.  On my iPhone 13 Pro Max the FloatingPlayerView overlaps the tab bar.  I did some research and figured out the safeAreaInserts would be better than hardcoded padding for the bottom of the view.  I've run it in Xcode with the iPhone 17 and iPad Air 11in in the simulator as well as my 13 Pro Max and it looks perfect.

I'm still learning swift and I am not confident that I can remove the customized padding without breaking something yet.  I don't know if this impacts the macOS since I've not tried the current version in macOS.

<img width="644" height="926" alt="Screenshot 2026-08-05 at 7 52 50 PM" src="https://github.com/user-attachments/assets/af83debe-c55f-4d2a-9879-4a48e1e2fe84" />
<img width="434" height="926" alt="Screenshot 2026-08-05 at 7 53 15 PM" src="https://github.com/user-attachments/assets/a4babf29-d3fa-40c1-84e3-f20e7366b709" />
<img width="1025" height="779" alt="Screenshot 2026-08-05 at 7 55 42 PM" src="https://github.com/user-attachments/assets/68c75c39-9b07-4071-a13a-e18f65144af0" />

Use the safe area to determine placement of the FloatingPlayerView.  This fixes excess bottom padding on iPhone 16e and too little padding on iPhone 13 Pro Max.  Should work normally on iPhones with small screens and large.